### PR TITLE
Update REM phase 2 docs and storage contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Local-first human-agent memory system.
 - Architecture/design: `docs/design.md`
 - Canonical tech stack: `docs/tech-stack.md`
 - Operator runbook: `docs/runbook.md`
+- API/CLI reference: `docs/api-cli-reference.md`
+- Data contracts: `docs/data-contracts.md`
+- Extension playbook: `docs/extension-playbook.md`
 
 ## Quick start
 

--- a/apps/ui/src/app.test.tsx
+++ b/apps/ui/src/app.test.tsx
@@ -9,5 +9,6 @@ describe("App", () => {
 
     expect(html).toContain("Proposal Inbox");
     expect(html).toContain("Draft Editor");
+    expect(html).toContain("Draft inbox");
   });
 });

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -1,0 +1,101 @@
+# rem Data Contracts
+
+This document defines canonical and derived data contracts for V1/Phase 2.
+
+## Canonical filesystem contracts
+
+Canonical root (`REM_STORE_ROOT`, default `./rem_store`):
+
+```text
+rem_store/
+  notes/<noteId>/
+    note.json
+    meta.json
+    sections.json
+  proposals/<proposalId>/
+    proposal.json
+    content.json
+    meta.json
+  drafts/<draftId>/
+    note.json
+    meta.json
+  plugins/<namespace>/
+    manifest.json
+    meta.json
+  events/YYYY-MM/YYYY-MM-DD.jsonl
+  index/rem.db
+```
+
+Contract rules:
+- Canonical writes are atomic (`tmp -> fsync -> rename`).
+- Canonical files are schema-validated before persist.
+- Canonical events are append-only JSONL.
+- SQLite is derived and rebuildable from canonical files/events.
+
+## Derived SQLite contracts
+
+Primary tables:
+- `notes`, `note_text`, `notes_fts`
+- `sections`
+- `proposals`
+- `drafts`
+- `plugins`
+- `events`
+
+Indexing constraints:
+- Notes, sections, proposals, drafts, plugins are upserted on successful canonical writes.
+- Event rows are append-only (`INSERT OR IGNORE` by `event_id`).
+- `rebuild-index` recreates `index/rem.db` and repopulates from canonical source.
+
+## Rebuild invariants
+
+After `rebuild-index`:
+1. `notes`, `proposals`, `drafts`, `plugins` counts match canonical directories.
+2. `events` count equals valid event JSONL lines (truncated final line tolerated).
+3. Search and section/proposal lookup parity is preserved for stable corpus.
+4. Rebuilt index contains same logical results as incremental indexing for existing data.
+
+## Event catalog (Phase 2)
+
+| Event type | Entity kind | Key payload fields |
+| --- | --- | --- |
+| `note.created` | `note` | `noteId`, `title`, `tags` |
+| `note.updated` | `note` | `noteId`, `title`, `tags`, proposal apply metadata |
+| `proposal.created` | `proposal` | `proposalId`, `noteId`, `sectionId`, `proposalType`, `status` |
+| `proposal.accepted` | `proposal` | `proposalId`, `noteId`, `sectionId`, `proposalType`, `status`, apply metadata |
+| `proposal.rejected` | `proposal` | `proposalId`, `noteId`, `sectionId`, `proposalType`, `status` |
+| `draft.created` | `draft` | `draftId`, `title`, `targetNoteId?`, `tags` |
+| `draft.updated` | `draft` | `draftId`, `title`, `targetNoteId?`, `tags` |
+| `plugin.registered` | `plugin` | `namespace`, `schemaVersion`, `registrationKind` |
+| `plugin.updated` | `plugin` | `namespace`, `schemaVersion`, `registrationKind` |
+
+## Plugin manifest contract
+
+Plugin manifest (`plugins/<namespace>/manifest.json`) fields:
+- `namespace`
+- `schemaVersion`
+- `payloadSchema`
+  - `type` must be `"object"`
+  - `required` string array
+  - `properties` map of `{ type, items? }`
+  - `additionalProperties` boolean
+
+Plugin metadata (`plugins/<namespace>/meta.json`) fields:
+- `namespace`
+- `schemaVersion`
+- `registeredAt`
+- `updatedAt`
+- `registrationKind` (`static` or `dynamic`)
+
+### Note payload validation rule
+
+On note writes, every key in `meta.plugins`:
+1. Must have a registered plugin manifest.
+2. Must satisfy that plugin’s `payloadSchema` required fields and property types.
+
+## Versioning expectations
+
+- Canonical objects include `schemaVersion`.
+- Event payloads are schema-versioned via `event.schemaVersion`.
+- Plugin manifest `schemaVersion` is independent per plugin namespace.
+- Migration posture remains non-destructive by default; `rebuild-index` is the primary repair path.

--- a/docs/extension-playbook.md
+++ b/docs/extension-playbook.md
@@ -1,0 +1,105 @@
+# rem Extension Playbook
+
+Use this guide when extending rem after Phase 2.
+
+## Safe extension workflow
+
+1. Add/adjust schema in `packages/schemas/src/index.ts`.
+2. Extend canonical persistence (`packages/store-fs/src/index.ts`) if storage changes.
+3. Extend derived indexing (`packages/index-sqlite/src/index.ts`).
+4. Update core orchestration (`packages/core/src/index.ts`).
+5. Expose interface changes in API (`apps/api/src/index.ts`) and CLI (`apps/cli/src/index.ts`).
+6. Add tests:
+   - unit tests for schema/store/index/core
+   - contract tests for API/CLI behavior
+7. Update docs (`docs/runbook.md`, `docs/api-cli-reference.md`, `docs/data-contracts.md`).
+
+## Add a new proposal type
+
+Checklist:
+1. Add value to `proposalTypeSchema`.
+2. Add apply logic in `RemCore.acceptProposal`.
+3. Emit proposal and note update events with typed payload details.
+4. Add tests:
+   - proposal creation validation
+   - acceptance behavior
+   - event payload assertions
+5. Add API/CLI support if new inputs are needed.
+
+Guardrails:
+- Never bypass section identity checks (`noteId + sectionId + fallbackPath`).
+- Keep acceptance behavior deterministic and idempotent per proposal state.
+
+## Add a new plugin capability
+
+Checklist:
+1. Define plugin manifest `payloadSchema`.
+2. Register via `registerPlugin` core flow (canonical + indexed + event emission).
+3. Validate note plugin payloads during note save.
+4. Add API/CLI examples for registration and usage.
+5. Update event catalog and data contract docs.
+
+Guardrails:
+- Reject note writes with unregistered plugin namespaces.
+- Reject payloads that violate required fields/type contracts.
+
+## Evolve schemas/events safely
+
+Checklist:
+1. Preserve backward compatibility where possible.
+2. Add version-aware readers before changing writers.
+3. Avoid destructive canonical rewrites by default.
+4. Ensure `rebuild-index` can replay canonical files/events into a valid DB.
+5. Add regression tests for old and new payload variants.
+
+Event evolution:
+- Add new event types rather than mutating semantics of existing types.
+- Keep old payload keys stable for existing consumers.
+
+## PRD to code traceability (Phase 2)
+
+| PRD capability | Primary implementation |
+| --- | --- |
+| Event query interface | `packages/index-sqlite/src/index.ts`, `packages/core/src/index.ts`, `apps/api/src/index.ts`, `apps/cli/src/index.ts` |
+| Draft first-class lifecycle | `packages/store-fs/src/index.ts`, `packages/index-sqlite/src/index.ts`, `packages/core/src/index.ts`, `apps/api/src/index.ts`, `apps/cli/src/index.ts`, `apps/ui/src/App.tsx` |
+| Plugin registry and schema enforcement | `packages/schemas/src/index.ts`, `packages/store-fs/src/index.ts`, `packages/core/src/index.ts`, `apps/api/src/index.ts`, `apps/cli/src/index.ts` |
+| Filtered search (tags/time) | `packages/index-sqlite/src/index.ts`, `packages/core/src/index.ts`, `apps/api/src/index.ts`, `apps/cli/src/index.ts` |
+| Contract coverage | `packages/core/src/phase2-contracts.test.ts` |
+
+## Future session handoff template
+
+Copy/paste this at session end:
+
+```text
+Session Hand-off
+Date:
+Branch:
+Related bead IDs:
+
+What shipped:
+- 
+
+What remains:
+- 
+
+Acceptance criteria status:
+- [ ] rem-...
+
+Validation run:
+- Tests:
+- Manual checks:
+
+Known risks/deviations:
+- 
+
+Next recommended starting issue:
+- 
+```
+
+## Session handoff checklist
+
+1. Update relevant bead statuses (`in_progress` -> `closed`) with notes.
+2. Confirm docs touched for any new interface/contract changes.
+3. Run tests and at least one manual smoke workflow on changed surfaces.
+4. Sync issue state (`bd sync`) and verify git branch status.
+5. Include explicit next step recommendation tied to a bead ID.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,13 +1,12 @@
 # rem Operator Runbook
 
-This runbook describes the local workflow for creating notes, reviewing proposals, rebuilding indexes, and troubleshooting common failures.
+This runbook covers local operation of rem across notes, proposals, drafts, plugins, event history, and rebuild workflows.
 
 ## Prerequisites
 
 ```bash
 bun install
 bun run lint
-bun run typecheck
 bun run test
 ```
 
@@ -23,63 +22,86 @@ bun run --cwd apps/ui dev
 
 Default API: `http://127.0.0.1:8787`
 
-## Note and proposal lifecycle (CLI)
+## Core lifecycle (CLI)
 
 ```bash
-# 1) Save or update a note
+# Save or update a note
 bun run --cwd apps/cli src/index.ts notes save --input ./note.json --json
 
-# 2) List sections to target
+# Save, list, and reopen drafts
+bun run --cwd apps/cli src/index.ts drafts save --input ./draft.json --json
+bun run --cwd apps/cli src/index.ts drafts list --json
+bun run --cwd apps/cli src/index.ts drafts get <draft-id> --json
+
+# Register and inspect plugins
+bun run --cwd apps/cli src/index.ts plugin register --manifest ./plugin-manifest.json --json
+bun run --cwd apps/cli src/index.ts plugin list --json
+
+# Search with metadata filters
+bun run --cwd apps/cli src/index.ts search "deploy" --tags ops --updated-since 2026-02-01T00:00:00.000Z --json
+
+# Event history
+bun run --cwd apps/cli src/index.ts events tail --limit 20 --json
+bun run --cwd apps/cli src/index.ts events list --entity-kind plugin --json
+```
+
+## Core lifecycle (API)
+
+```bash
+# Save note with plugin payload
+curl -X POST "http://127.0.0.1:8787/notes" \
+  -H "content-type: application/json" \
+  -d @note.json
+
+# Draft create/list/get
+curl -X POST "http://127.0.0.1:8787/drafts" \
+  -H "content-type: application/json" \
+  -d @draft.json
+curl "http://127.0.0.1:8787/drafts?limit=20"
+curl "http://127.0.0.1:8787/drafts/<draft-id>"
+
+# Plugin registration/listing
+curl -X POST "http://127.0.0.1:8787/plugins/register" \
+  -H "content-type: application/json" \
+  -d @plugin-register.json
+curl "http://127.0.0.1:8787/plugins?limit=50"
+
+# Search with tags/time filters
+curl "http://127.0.0.1:8787/search?q=deploy&tags=ops,weekly&updatedSince=2026-02-01T00:00:00.000Z"
+
+# Event history
+curl "http://127.0.0.1:8787/events?limit=50"
+curl "http://127.0.0.1:8787/events?entityKind=draft&since=2026-02-01T00:00:00.000Z"
+```
+
+## Proposal review workflow
+
+```bash
+# List sections to target
 bun run --cwd apps/cli src/index.ts sections list --note <note-id> --json
 
-# 3) Create an agent proposal
+# Create a proposal
 bun run --cwd apps/cli src/index.ts proposals create \
   --note <note-id> \
   --section <section-id> \
-  --text "Replacement section content" \
+  --text "Replacement content" \
   --json
 
-# 4) Review queue and accept or reject
+# Review queue
 bun run --cwd apps/cli src/index.ts proposals list --status open --json
 bun run --cwd apps/cli src/index.ts proposals accept <proposal-id> --json
 bun run --cwd apps/cli src/index.ts proposals reject <proposal-id> --json
 ```
 
-## Note and proposal lifecycle (API)
-
-```bash
-# Save note
-curl -X POST "http://127.0.0.1:8787/notes" \
-  -H "content-type: application/json" \
-  -d @note.json
-
-# List note sections
-curl "http://127.0.0.1:8787/sections?noteId=<note-id>"
-
-# Create proposal
-curl -X POST "http://127.0.0.1:8787/proposals" \
-  -H "content-type: application/json" \
-  -d '{
-    "target": { "noteId": "<note-id>", "sectionId": "<section-id>" },
-    "proposalType": "replace_section",
-    "content": { "format": "text", "content": "Replacement section content" },
-    "actor": { "kind": "agent", "id": "api-agent" }
-  }'
-
-# Accept or reject
-curl -X POST "http://127.0.0.1:8787/proposals/<proposal-id>/accept" -H "content-type: application/json" -d '{}'
-curl -X POST "http://127.0.0.1:8787/proposals/<proposal-id>/reject" -H "content-type: application/json" -d '{}'
-```
-
 ## Rebuild derived index
 
-If SQLite data is stale or corrupted, rebuild from canonical files/events.
+If SQLite is stale or removed, rebuild from canonical files/events:
 
 ```bash
 bun run --cwd apps/cli src/index.ts rebuild-index --json
 ```
 
-Expected: note/proposal/event counts should match canonical filesystem state.
+Expected: `notes`, `proposals`, `drafts`, `plugins`, and `events` counts match canonical filesystem state.
 
 ## Troubleshooting
 
@@ -87,36 +109,38 @@ Expected: note/proposal/event counts should match canonical filesystem state.
 
 Symptoms:
 - API returns `{"error":{"code":"bad_request",...}}`
-- CLI returns `proposal_create_failed` or `invalid_format`
+- CLI returns `*_failed` errors
 
 Checks:
-- Ensure proposal actor is agent for creation.
-- Ensure proposal target `noteId` and `sectionId` exist.
-- Ensure proposal content shape matches `format` (`text` => string, `lexical` => lexical state).
+- Plugin payload namespaces must be registered before note writes.
+- Plugin payload must satisfy manifest `payloadSchema` required fields/types.
+- Proposal content format must match payload shape.
 
-### Missing section errors
+### Missing target references
 
 Symptoms:
 - `Target section not found`
+- `Draft not found`
 
 Checks:
-- Re-list sections and refresh IDs:
-  `bun run --cwd apps/cli src/index.ts sections list --note <note-id> --json`
-- Use fallback path if section IDs changed after note edits.
+- Re-list sections: `bun run --cwd apps/cli src/index.ts sections list --note <note-id> --json`
+- Re-list drafts: `bun run --cwd apps/cli src/index.ts drafts list --json`
 
 ### Stale index symptoms
 
 Symptoms:
-- Proposal list/count mismatch
-- Sections missing in API/CLI responses
+- Event list misses recent writes
+- Draft/plugin counts in `status` are wrong
 
 Recovery:
 - Run `rebuild-index`.
-- Re-run status commands and confirm counts.
+- Re-check via:
+  `bun run --cwd apps/cli src/index.ts status --json`
+  `bun run --cwd apps/cli src/index.ts events tail --json`
 
 ### Event log crash tail
 
-The system tolerates truncated final JSONL lines caused by abrupt process termination. Rebuild should skip the malformed last line and recover valid prior events.
+Truncated final JSONL lines are tolerated during rebuild. Recovery keeps prior valid events and skips only the malformed final line.
 
 ## Validation checklist
 
@@ -124,12 +148,12 @@ Run before shipping:
 
 ```bash
 bun run lint
-bun run typecheck
 bun run test
 ```
 
 Manual smoke checks:
-1. Save note and read note text.
-2. Create proposal and confirm it appears in open list.
-3. Accept proposal and verify note text changed.
-4. Rebuild index and confirm proposal/section counts remain consistent.
+1. Register plugin and confirm `plugin.registered` appears in events.
+2. Save note with valid plugin payload and verify filtered search by tags.
+3. Save and reopen a draft via API and CLI.
+4. Confirm `events list` returns note/draft/plugin activity.
+5. Rebuild index and confirm status counts remain consistent.

--- a/packages/core/src/phase2-contracts.test.ts
+++ b/packages/core/src/phase2-contracts.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+function lexicalStateWithText(text: string): unknown {
+  return {
+    root: {
+      type: "root",
+      version: 1,
+      children: [
+        {
+          type: "paragraph",
+          version: 1,
+          children: [
+            {
+              type: "text",
+              version: 1,
+              text,
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+function parseJsonStdout(stdout: Uint8Array): unknown {
+  return JSON.parse(Buffer.from(stdout).toString("utf8"));
+}
+
+async function waitForApiReady(url: string): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return;
+      }
+      lastError = new Error(`API status returned ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  throw new Error(`API did not become ready: ${String(lastError)}`);
+}
+
+describe("phase 2 contracts", () => {
+  test("API exposes plugin, draft, event, and filtered-search contracts", async () => {
+    const storeRoot = await mkdtemp(path.join(tmpdir(), "rem-phase2-api-contract-"));
+    const api = Bun.spawn(["bun", "run", "--cwd", "apps/api", "src/index.ts"], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        REM_STORE_ROOT: storeRoot,
+      },
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+
+    try {
+      await waitForApiReady("http://127.0.0.1:8787/status");
+
+      const registerResponse = await fetch("http://127.0.0.1:8787/plugins/register", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          manifest: {
+            namespace: "tasks",
+            schemaVersion: "v1",
+            payloadSchema: {
+              type: "object",
+              required: ["board"],
+              properties: {
+                board: {
+                  type: "string",
+                },
+              },
+              additionalProperties: false,
+            },
+          },
+          actor: { kind: "human", id: "tester" },
+        }),
+      });
+      expect(registerResponse.status).toBe(200);
+
+      const noteResponse = await fetch("http://127.0.0.1:8787/notes", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          title: "Contract note",
+          lexicalState: lexicalStateWithText("contract alpha"),
+          tags: ["ops"],
+          plugins: {
+            tasks: {
+              board: "infra",
+            },
+          },
+        }),
+      });
+      expect(noteResponse.status).toBe(200);
+
+      const draftResponse = await fetch("http://127.0.0.1:8787/drafts", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          title: "Draft contract",
+          lexicalState: lexicalStateWithText("draft text"),
+          tags: ["draft"],
+          author: { kind: "agent", id: "agent-1" },
+        }),
+      });
+      expect(draftResponse.status).toBe(200);
+
+      const drafts = (await (await fetch("http://127.0.0.1:8787/drafts")).json()) as Array<{
+        id: string;
+      }>;
+      expect(drafts.length).toBe(1);
+
+      const events = (await (
+        await fetch("http://127.0.0.1:8787/events?entityKind=plugin")
+      ).json()) as Array<{
+        type: string;
+      }>;
+      expect(events.length).toBe(1);
+      expect(events[0]?.type).toBe("plugin.registered");
+
+      const search = (await (
+        await fetch("http://127.0.0.1:8787/search?q=contract&tags=ops")
+      ).json()) as Array<{
+        id: string;
+      }>;
+      expect(search.length).toBe(1);
+    } finally {
+      api.kill();
+      await api.exited;
+      await rm(storeRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("CLI exposes plugin, draft, event, and filtered-search contracts", async () => {
+    const storeRoot = await mkdtemp(path.join(tmpdir(), "rem-phase2-cli-contract-"));
+    const manifestPath = path.join(storeRoot, "manifest.json");
+    const notePath = path.join(storeRoot, "note.json");
+    const draftPath = path.join(storeRoot, "draft.json");
+
+    try {
+      await writeFile(
+        manifestPath,
+        JSON.stringify({
+          namespace: "tasks",
+          schemaVersion: "v1",
+          payloadSchema: {
+            type: "object",
+            required: ["board"],
+            properties: {
+              board: {
+                type: "string",
+              },
+            },
+            additionalProperties: false,
+          },
+        }),
+      );
+
+      await writeFile(
+        notePath,
+        JSON.stringify({
+          title: "CLI Note",
+          lexicalState: lexicalStateWithText("cli alpha"),
+          tags: ["ops"],
+          plugins: {
+            tasks: {
+              board: "infra",
+            },
+          },
+        }),
+      );
+
+      await writeFile(
+        draftPath,
+        JSON.stringify({
+          title: "CLI Draft",
+          lexicalState: lexicalStateWithText("cli draft"),
+          tags: ["draft"],
+          author: { kind: "agent", id: "cli-agent" },
+        }),
+      );
+
+      const env = {
+        ...process.env,
+        REM_STORE_ROOT: storeRoot,
+      };
+
+      const registerPlugin = Bun.spawnSync(
+        [
+          "bun",
+          "run",
+          "--cwd",
+          "apps/cli",
+          "src/index.ts",
+          "plugin",
+          "register",
+          "--manifest",
+          manifestPath,
+          "--json",
+        ],
+        {
+          cwd: process.cwd(),
+          env,
+          stderr: "pipe",
+          stdout: "pipe",
+        },
+      );
+      expect(registerPlugin.exitCode).toBe(0);
+
+      const saveNote = Bun.spawnSync(
+        [
+          "bun",
+          "run",
+          "--cwd",
+          "apps/cli",
+          "src/index.ts",
+          "notes",
+          "save",
+          "--input",
+          notePath,
+          "--json",
+        ],
+        {
+          cwd: process.cwd(),
+          env,
+          stderr: "pipe",
+          stdout: "pipe",
+        },
+      );
+      expect(saveNote.exitCode).toBe(0);
+
+      const saveDraft = Bun.spawnSync(
+        [
+          "bun",
+          "run",
+          "--cwd",
+          "apps/cli",
+          "src/index.ts",
+          "drafts",
+          "save",
+          "--input",
+          draftPath,
+          "--json",
+        ],
+        {
+          cwd: process.cwd(),
+          env,
+          stderr: "pipe",
+          stdout: "pipe",
+        },
+      );
+      expect(saveDraft.exitCode).toBe(0);
+
+      const search = Bun.spawnSync(
+        [
+          "bun",
+          "run",
+          "--cwd",
+          "apps/cli",
+          "src/index.ts",
+          "search",
+          "alpha",
+          "--tags",
+          "ops",
+          "--json",
+        ],
+        {
+          cwd: process.cwd(),
+          env,
+          stderr: "pipe",
+          stdout: "pipe",
+        },
+      );
+      expect(search.exitCode).toBe(0);
+      const searchPayload = parseJsonStdout(search.stdout) as Array<{ title: string }>;
+      expect(searchPayload.length).toBe(1);
+      expect(searchPayload[0]?.title).toBe("CLI Note");
+
+      const drafts = Bun.spawnSync(
+        ["bun", "run", "--cwd", "apps/cli", "src/index.ts", "drafts", "list", "--json"],
+        {
+          cwd: process.cwd(),
+          env,
+          stderr: "pipe",
+          stdout: "pipe",
+        },
+      );
+      expect(drafts.exitCode).toBe(0);
+      const draftsPayload = parseJsonStdout(drafts.stdout) as Array<{ title: string }>;
+      expect(draftsPayload.length).toBe(1);
+      expect(draftsPayload[0]?.title).toBe("CLI Draft");
+
+      const events = Bun.spawnSync(
+        ["bun", "run", "--cwd", "apps/cli", "src/index.ts", "events", "tail", "--json"],
+        {
+          cwd: process.cwd(),
+          env,
+          stderr: "pipe",
+          stdout: "pipe",
+        },
+      );
+      expect(events.exitCode).toBe(0);
+      const eventsPayload = parseJsonStdout(events.stdout) as Array<{ type: string }>;
+      expect(eventsPayload.length).toBeGreaterThanOrEqual(3);
+      expect(eventsPayload.some((event) => event.type === "plugin.registered")).toBeTrue();
+    } finally {
+      await rm(storeRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/index-sqlite/src/index.test.ts
+++ b/packages/index-sqlite/src/index.test.ts
@@ -3,12 +3,20 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import type { NoteMeta, NoteSection, Proposal, RemEvent } from "@rem/schemas";
+import type {
+  DraftMeta,
+  LexicalState,
+  NoteMeta,
+  NoteSection,
+  PluginManifest,
+  Proposal,
+  RemEvent,
+} from "@rem/schemas";
 
 import { RemIndex } from "./index";
 
-function makeNoteMeta(noteId: string): NoteMeta {
-  return {
+function makeNoteMeta(noteId: string, overrides?: Partial<NoteMeta>): NoteMeta {
+  const base: NoteMeta = {
     id: noteId,
     schemaVersion: "v1",
     title: "Demo Note",
@@ -18,6 +26,11 @@ function makeNoteMeta(noteId: string): NoteMeta {
     tags: ["demo"],
     plugins: {},
     sectionIndexVersion: "v1",
+  };
+
+  return {
+    ...base,
+    ...overrides,
   };
 }
 
@@ -63,6 +76,86 @@ function makeEvent(eventId: string): RemEvent {
     entity: { kind: "proposal", id: "proposal-1" },
     payload: {
       proposalId: "proposal-1",
+    },
+  };
+}
+
+function makeCustomEvent(input: {
+  eventId: string;
+  timestamp: string;
+  type: string;
+  actorKind: "human" | "agent";
+  actorId?: string;
+  entityKind: "note" | "proposal" | "draft" | "plugin";
+  entityId: string;
+}): RemEvent {
+  return {
+    eventId: input.eventId,
+    schemaVersion: "v1",
+    timestamp: input.timestamp,
+    type: input.type,
+    actor: {
+      kind: input.actorKind,
+      id: input.actorId,
+    },
+    entity: {
+      kind: input.entityKind,
+      id: input.entityId,
+    },
+    payload: {
+      entityId: input.entityId,
+    },
+  };
+}
+
+function makeDraftMeta(draftId: string, updatedAt: string): DraftMeta {
+  return {
+    id: draftId,
+    schemaVersion: "v1",
+    createdAt: "2026-02-07T00:00:00.000Z",
+    updatedAt,
+    author: { kind: "agent", id: "agent-1" },
+    targetNoteId: "note-1",
+    title: `Draft ${draftId}`,
+    tags: ["draft"],
+  };
+}
+
+function makeDraftState(text: string): LexicalState {
+  return {
+    root: {
+      type: "root",
+      version: 1,
+      children: [
+        {
+          type: "paragraph",
+          version: 1,
+          children: [
+            {
+              type: "text",
+              version: 1,
+              text,
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+function makePluginManifest(namespace: string, schemaVersion: string): PluginManifest {
+  return {
+    namespace,
+    schemaVersion,
+    payloadSchema: {
+      type: "object",
+      required: ["board"],
+      properties: {
+        board: {
+          type: "string",
+        },
+      },
+      additionalProperties: false,
     },
   };
 }
@@ -128,6 +221,187 @@ describe("RemIndex proposal and section indexing", () => {
       expect(stats.noteCount).toBe(1);
       expect(stats.proposalCount).toBe(1);
       expect(stats.eventCount).toBe(1);
+    } finally {
+      index.close();
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test("lists indexed events with ordering and filters", async () => {
+    const workspace = await mkdtemp(path.join(tmpdir(), "rem-index-events-query-"));
+    const dbPath = path.join(workspace, "rem.db");
+    const index = new RemIndex(dbPath);
+
+    try {
+      index.insertEvent(
+        makeCustomEvent({
+          eventId: "event-note",
+          timestamp: "2026-02-07T00:00:00.000Z",
+          type: "note.created",
+          actorKind: "human",
+          actorId: "human-1",
+          entityKind: "note",
+          entityId: "note-1",
+        }),
+      );
+      index.insertEvent(
+        makeCustomEvent({
+          eventId: "event-proposal",
+          timestamp: "2026-02-07T00:01:00.000Z",
+          type: "proposal.created",
+          actorKind: "agent",
+          actorId: "agent-1",
+          entityKind: "proposal",
+          entityId: "proposal-1",
+        }),
+      );
+      index.insertEvent(
+        makeCustomEvent({
+          eventId: "event-draft",
+          timestamp: "2026-02-07T00:02:00.000Z",
+          type: "draft.updated",
+          actorKind: "agent",
+          actorId: "agent-1",
+          entityKind: "draft",
+          entityId: "draft-1",
+        }),
+      );
+
+      const latestFirst = index.listEvents();
+      expect(latestFirst.map((event) => event.eventId)).toEqual([
+        "event-draft",
+        "event-proposal",
+        "event-note",
+      ]);
+
+      const sinceFiltered = index.listEvents({
+        since: "2026-02-07T00:01:00.000Z",
+      });
+      expect(sinceFiltered.map((event) => event.eventId)).toEqual([
+        "event-draft",
+        "event-proposal",
+      ]);
+
+      const agentProposal = index.listEvents({
+        actorKind: "agent",
+        actorId: "agent-1",
+        type: "proposal.created",
+        entityKind: "proposal",
+      });
+      expect(agentProposal.length).toBe(1);
+      expect(agentProposal[0]?.eventId).toBe("event-proposal");
+    } finally {
+      index.close();
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test("applies tag and updated-time filters during search", async () => {
+    const workspace = await mkdtemp(path.join(tmpdir(), "rem-index-search-filters-"));
+    const dbPath = path.join(workspace, "rem.db");
+    const index = new RemIndex(dbPath);
+
+    try {
+      index.upsertNote(
+        makeNoteMeta("note-ops", {
+          title: "Ops Note",
+          tags: ["ops", "daily"],
+          updatedAt: "2026-02-07T00:10:00.000Z",
+        }),
+        "deploy alpha",
+      );
+      index.upsertNote(
+        makeNoteMeta("note-engineering", {
+          title: "Engineering Note",
+          tags: ["engineering"],
+          updatedAt: "2026-02-07T00:20:00.000Z",
+        }),
+        "deploy alpha",
+      );
+      index.upsertNote(
+        makeNoteMeta("note-ops-late", {
+          title: "Ops Late",
+          tags: ["ops"],
+          updatedAt: "2026-02-07T00:30:00.000Z",
+        }),
+        "deploy alpha",
+      );
+
+      const opsOnly = index.search("deploy", {
+        tags: ["ops"],
+      });
+      expect(opsOnly.map((item) => item.id)).toEqual(["note-ops-late", "note-ops"]);
+
+      const opsAndDaily = index.search("deploy", {
+        tags: ["ops", "daily"],
+      });
+      expect(opsAndDaily.map((item) => item.id)).toEqual(["note-ops"]);
+
+      const recentWindow = index.search("deploy", {
+        updatedSince: "2026-02-07T00:15:00.000Z",
+        updatedUntil: "2026-02-07T00:25:00.000Z",
+      });
+      expect(recentWindow.map((item) => item.id)).toEqual(["note-engineering"]);
+    } finally {
+      index.close();
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test("upserts drafts and lists summaries by updated timestamp", async () => {
+    const workspace = await mkdtemp(path.join(tmpdir(), "rem-index-drafts-"));
+    const dbPath = path.join(workspace, "rem.db");
+    const index = new RemIndex(dbPath);
+
+    try {
+      index.upsertDraft(
+        "draft-a",
+        makeDraftState("draft A"),
+        makeDraftMeta("draft-a", "2026-02-07T00:05:00.000Z"),
+      );
+      index.upsertDraft(
+        "draft-b",
+        makeDraftState("draft B"),
+        makeDraftMeta("draft-b", "2026-02-07T00:10:00.000Z"),
+      );
+
+      const summaries = index.listDrafts();
+      expect(summaries.map((draft) => draft.id)).toEqual(["draft-b", "draft-a"]);
+      expect(summaries[0]?.title).toBe("Draft draft-b");
+
+      const draft = index.getDraft("draft-a");
+      expect(draft?.id).toBe("draft-a");
+      expect(draft?.meta.author.kind).toBe("agent");
+    } finally {
+      index.close();
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test("upserts and lists plugin manifests", async () => {
+    const workspace = await mkdtemp(path.join(tmpdir(), "rem-index-plugins-"));
+    const dbPath = path.join(workspace, "rem.db");
+    const index = new RemIndex(dbPath);
+
+    try {
+      index.upsertPluginManifest(
+        "tasks",
+        "v1",
+        "2026-02-07T00:00:00.000Z",
+        "2026-02-07T00:00:00.000Z",
+        makePluginManifest("tasks", "v1"),
+      );
+      index.upsertPluginManifest(
+        "meetings",
+        "v2",
+        "2026-02-07T00:00:00.000Z",
+        "2026-02-07T00:05:00.000Z",
+        makePluginManifest("meetings", "v2"),
+      );
+
+      const manifests = index.listPluginManifests();
+      expect(manifests.map((item) => item.namespace)).toEqual(["meetings", "tasks"]);
+      expect(manifests[0]?.manifest.schemaVersion).toBe("v2");
     } finally {
       index.close();
       await rm(workspace, { recursive: true, force: true });

--- a/packages/index-sqlite/src/index.ts
+++ b/packages/index-sqlite/src/index.ts
@@ -1,14 +1,25 @@
-import { Database } from "bun:sqlite";
+import { Database, type SQLQueryBindings } from "bun:sqlite";
 import { createHash } from "node:crypto";
 import { mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 
-import type { NoteMeta, NoteSection, Proposal, ProposalStatus, RemEvent } from "@rem/schemas";
+import type {
+  DraftMeta,
+  LexicalState,
+  NoteMeta,
+  NoteSection,
+  PluginManifest,
+  Proposal,
+  ProposalStatus,
+  RemEvent,
+} from "@rem/schemas";
 
 export interface IndexStats {
   noteCount: number;
   proposalCount: number;
   eventCount: number;
+  draftCount: number;
+  pluginCount: number;
 }
 
 export interface SearchResult {
@@ -16,6 +27,13 @@ export interface SearchResult {
   title: string;
   updatedAt: string;
   snippet: string;
+}
+
+export interface SearchFilters {
+  limit?: number;
+  tags?: string[];
+  updatedSince?: string;
+  updatedUntil?: string;
 }
 
 export interface IndexedSection {
@@ -41,6 +59,52 @@ export interface IndexedProposal {
   rationale: string | null;
 }
 
+export interface IndexedDraftSummary {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  authorKind: RemEvent["actor"]["kind"];
+  authorId: string | null;
+  targetNoteId: string | null;
+  title: string;
+  tags: string[];
+}
+
+export interface IndexedDraftRecord {
+  id: string;
+  note: LexicalState;
+  meta: DraftMeta;
+}
+
+export interface IndexedPluginManifest {
+  namespace: string;
+  schemaVersion: string;
+  registeredAt: string;
+  updatedAt: string;
+  manifest: PluginManifest;
+}
+
+export interface EventQueryInput {
+  since?: string;
+  limit?: number;
+  type?: string;
+  actorKind?: RemEvent["actor"]["kind"];
+  actorId?: string;
+  entityKind?: RemEvent["entity"]["kind"];
+  entityId?: string;
+}
+
+export interface IndexedEvent {
+  eventId: string;
+  timestamp: string;
+  type: string;
+  actorKind: RemEvent["actor"]["kind"];
+  actorId: string | null;
+  entityKind: RemEvent["entity"]["kind"];
+  entityId: string;
+  payload: Record<string, unknown>;
+}
+
 function parseFallbackPath(raw: string): string[] {
   try {
     const parsed = JSON.parse(raw) as unknown;
@@ -49,6 +113,40 @@ function parseFallbackPath(raw: string): string[] {
     }
   } catch {
     // Ignore malformed fallback path payloads and return empty fallback path.
+  }
+
+  return [];
+}
+
+function parsePayloadJson(raw: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // Ignore malformed payloads and return empty object.
+  }
+
+  return {};
+}
+
+function dedupeStrings(values: string[] | undefined): string[] {
+  if (!values || values.length === 0) {
+    return [];
+  }
+
+  return [...new Set(values.map((value) => value.trim()).filter((value) => value.length > 0))];
+}
+
+function parseStringArray(raw: string): string[] {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (Array.isArray(parsed) && parsed.every((value) => typeof value === "string")) {
+      return parsed;
+    }
+  } catch {
+    // Ignore malformed arrays and return empty list.
   }
 
   return [];
@@ -118,6 +216,31 @@ export class RemIndex {
 
       CREATE INDEX IF NOT EXISTS idx_proposals_status_updated ON proposals(status, updated_at DESC);
 
+      CREATE TABLE IF NOT EXISTS drafts (
+        id TEXT PRIMARY KEY,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        author_kind TEXT NOT NULL,
+        author_id TEXT,
+        target_note_id TEXT,
+        title TEXT NOT NULL,
+        tags_json TEXT NOT NULL,
+        note_json TEXT NOT NULL,
+        meta_json TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_drafts_updated ON drafts(updated_at DESC);
+
+      CREATE TABLE IF NOT EXISTS plugins (
+        namespace TEXT PRIMARY KEY,
+        schema_version TEXT NOT NULL,
+        registered_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        manifest_json TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_plugins_updated ON plugins(updated_at DESC);
+
       CREATE TABLE IF NOT EXISTS events (
         event_id TEXT PRIMARY KEY,
         timestamp TEXT NOT NULL,
@@ -128,6 +251,11 @@ export class RemIndex {
         entity_id TEXT NOT NULL,
         payload_json TEXT NOT NULL
       );
+
+      CREATE INDEX IF NOT EXISTS idx_events_timestamp ON events(timestamp DESC);
+      CREATE INDEX IF NOT EXISTS idx_events_type_timestamp ON events(type, timestamp DESC);
+      CREATE INDEX IF NOT EXISTS idx_events_actor_timestamp ON events(actor_kind, actor_id, timestamp DESC);
+      CREATE INDEX IF NOT EXISTS idx_events_entity_timestamp ON events(entity_kind, entity_id, timestamp DESC);
     `);
   }
 
@@ -289,6 +417,168 @@ export class RemIndex {
       );
   }
 
+  upsertDraft(draftId: string, note: LexicalState, meta: DraftMeta): void {
+    this.db
+      .query(
+        `INSERT INTO drafts (
+          id,
+          created_at,
+          updated_at,
+          author_kind,
+          author_id,
+          target_note_id,
+          title,
+          tags_json,
+          note_json,
+          meta_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+          updated_at = excluded.updated_at,
+          author_kind = excluded.author_kind,
+          author_id = excluded.author_id,
+          target_note_id = excluded.target_note_id,
+          title = excluded.title,
+          tags_json = excluded.tags_json,
+          note_json = excluded.note_json,
+          meta_json = excluded.meta_json`,
+      )
+      .run(
+        draftId,
+        meta.createdAt,
+        meta.updatedAt,
+        meta.author.kind,
+        meta.author.id ?? null,
+        meta.targetNoteId ?? null,
+        meta.title,
+        JSON.stringify(meta.tags),
+        JSON.stringify(note),
+        JSON.stringify(meta),
+      );
+  }
+
+  listDrafts(limit = 100): IndexedDraftSummary[] {
+    const normalizedLimit = Math.max(1, Math.min(limit, 1000));
+    const rows = this.db
+      .query(
+        `SELECT
+          id,
+          created_at AS createdAt,
+          updated_at AS updatedAt,
+          author_kind AS authorKind,
+          author_id AS authorId,
+          target_note_id AS targetNoteId,
+          title,
+          tags_json AS tagsJson
+        FROM drafts
+        ORDER BY updated_at DESC
+        LIMIT ?`,
+      )
+      .all(normalizedLimit) as Array<{
+      id: string;
+      createdAt: string;
+      updatedAt: string;
+      authorKind: RemEvent["actor"]["kind"];
+      authorId: string | null;
+      targetNoteId: string | null;
+      title: string;
+      tagsJson: string;
+    }>;
+
+    return rows.map((row) => ({
+      id: row.id,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+      authorKind: row.authorKind,
+      authorId: row.authorId,
+      targetNoteId: row.targetNoteId,
+      title: row.title,
+      tags: parseStringArray(row.tagsJson),
+    }));
+  }
+
+  getDraft(draftId: string): IndexedDraftRecord | null {
+    const row = this.db
+      .query(
+        `SELECT
+          id,
+          note_json AS noteJson,
+          meta_json AS metaJson
+        FROM drafts
+        WHERE id = ?
+        LIMIT 1`,
+      )
+      .get(draftId) as {
+      id: string;
+      noteJson: string;
+      metaJson: string;
+    } | null;
+
+    if (!row) {
+      return null;
+    }
+
+    return {
+      id: row.id,
+      note: JSON.parse(row.noteJson) as LexicalState,
+      meta: JSON.parse(row.metaJson) as DraftMeta,
+    };
+  }
+
+  upsertPluginManifest(
+    namespace: string,
+    schemaVersion: string,
+    registeredAt: string,
+    updatedAt: string,
+    manifest: PluginManifest,
+  ): void {
+    this.db
+      .query(
+        `INSERT INTO plugins (
+          namespace,
+          schema_version,
+          registered_at,
+          updated_at,
+          manifest_json
+        ) VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(namespace) DO UPDATE SET
+          schema_version = excluded.schema_version,
+          updated_at = excluded.updated_at,
+          manifest_json = excluded.manifest_json`,
+      )
+      .run(namespace, schemaVersion, registeredAt, updatedAt, JSON.stringify(manifest));
+  }
+
+  listPluginManifests(limit = 100): IndexedPluginManifest[] {
+    const normalizedLimit = Math.max(1, Math.min(limit, 1000));
+    const rows = this.db
+      .query(
+        `SELECT
+          namespace,
+          schema_version AS schemaVersion,
+          registered_at AS registeredAt,
+          updated_at AS updatedAt,
+          manifest_json AS manifestJson
+        FROM plugins
+        ORDER BY namespace ASC
+        LIMIT ?`,
+      )
+      .all(normalizedLimit) as Array<{
+      namespace: string;
+      schemaVersion: string;
+      registeredAt: string;
+      updatedAt: string;
+      manifestJson: string;
+    }>;
+
+    return rows.map((row) => ({
+      namespace: row.namespace,
+      schemaVersion: row.schemaVersion,
+      registeredAt: row.registeredAt,
+      updatedAt: row.updatedAt,
+      manifest: JSON.parse(row.manifestJson) as PluginManifest,
+    }));
+  }
+
   listProposals(status?: ProposalStatus, limit = 100): IndexedProposal[] {
     if (status) {
       return this.db
@@ -356,11 +646,111 @@ export class RemIndex {
       );
   }
 
-  search(query: string, limit = 20): SearchResult[] {
+  listEvents(input?: EventQueryInput): IndexedEvent[] {
+    const clauses: string[] = [];
+    const params: SQLQueryBindings[] = [];
+    const limit = Math.max(1, Math.min(input?.limit ?? 100, 1000));
+
+    if (input?.since) {
+      clauses.push("timestamp >= ?");
+      params.push(input.since);
+    }
+
+    if (input?.type) {
+      clauses.push("type = ?");
+      params.push(input.type);
+    }
+
+    if (input?.actorKind) {
+      clauses.push("actor_kind = ?");
+      params.push(input.actorKind);
+    }
+
+    if (input?.actorId) {
+      clauses.push("actor_id = ?");
+      params.push(input.actorId);
+    }
+
+    if (input?.entityKind) {
+      clauses.push("entity_kind = ?");
+      params.push(input.entityKind);
+    }
+
+    if (input?.entityId) {
+      clauses.push("entity_id = ?");
+      params.push(input.entityId);
+    }
+
+    params.push(limit);
+
+    const whereClause = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
+    const rows = this.db
+      .query(
+        `SELECT
+          event_id AS eventId,
+          timestamp,
+          type,
+          actor_kind AS actorKind,
+          actor_id AS actorId,
+          entity_kind AS entityKind,
+          entity_id AS entityId,
+          payload_json AS payloadJson
+        FROM events
+        ${whereClause}
+        ORDER BY timestamp DESC, event_id DESC
+        LIMIT ?`,
+      )
+      .all(...params) as Array<{
+      eventId: string;
+      timestamp: string;
+      type: string;
+      actorKind: RemEvent["actor"]["kind"];
+      actorId: string | null;
+      entityKind: RemEvent["entity"]["kind"];
+      entityId: string;
+      payloadJson: string;
+    }>;
+
+    return rows.map((row) => ({
+      eventId: row.eventId,
+      timestamp: row.timestamp,
+      type: row.type,
+      actorKind: row.actorKind,
+      actorId: row.actorId,
+      entityKind: row.entityKind,
+      entityId: row.entityId,
+      payload: parsePayloadJson(row.payloadJson),
+    }));
+  }
+
+  search(query: string, filters?: SearchFilters): SearchResult[] {
     const normalized = query.trim();
     if (!normalized) {
       return [];
     }
+
+    const whereClauses = ["notes_fts MATCH ?"];
+    const params: SQLQueryBindings[] = [normalized];
+    const limit = Math.max(1, Math.min(filters?.limit ?? 20, 1000));
+
+    if (filters?.updatedSince) {
+      whereClauses.push("notes.updated_at >= ?");
+      params.push(filters.updatedSince);
+    }
+
+    if (filters?.updatedUntil) {
+      whereClauses.push("notes.updated_at <= ?");
+      params.push(filters.updatedUntil);
+    }
+
+    for (const tag of dedupeStrings(filters?.tags)) {
+      whereClauses.push(
+        "EXISTS (SELECT 1 FROM json_each(notes.tags_json) WHERE json_each.value = ?)",
+      );
+      params.push(tag);
+    }
+
+    params.push(limit);
 
     return this.db
       .query(
@@ -371,11 +761,11 @@ export class RemIndex {
           snippet(notes_fts, 2, '[', ']', '…', 20) AS snippet
         FROM notes_fts
         JOIN notes ON notes.id = notes_fts.note_id
-        WHERE notes_fts MATCH ?
+        WHERE ${whereClauses.join(" AND ")}
         ORDER BY bm25(notes_fts), notes.updated_at DESC
         LIMIT ?`,
       )
-      .all(normalized, limit) as SearchResult[];
+      .all(...params) as SearchResult[];
   }
 
   getStats(): IndexStats {
@@ -384,7 +774,9 @@ export class RemIndex {
         `SELECT
           (SELECT COUNT(*) FROM notes) AS noteCount,
           (SELECT COUNT(*) FROM proposals) AS proposalCount,
-          (SELECT COUNT(*) FROM events) AS eventCount`,
+          (SELECT COUNT(*) FROM events) AS eventCount,
+          (SELECT COUNT(*) FROM drafts) AS draftCount,
+          (SELECT COUNT(*) FROM plugins) AS pluginCount`,
       )
       .get() as IndexStats;
   }

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -170,6 +170,43 @@ export const draftMetaSchema = z.object({
   tags: z.array(z.string()).default([]),
 });
 
+export const pluginNamespaceSchema = z
+  .string()
+  .min(1)
+  .regex(/^[a-z0-9]+(?:[._-][a-z0-9]+)*$/);
+
+export const pluginFieldTypeSchema = z.enum(["string", "number", "boolean", "object", "array"]);
+
+export const pluginFieldSchema = z.object({
+  type: pluginFieldTypeSchema,
+  items: z
+    .object({
+      type: pluginFieldTypeSchema,
+    })
+    .optional(),
+});
+
+export const pluginPayloadSchemaSchema = z.object({
+  type: z.literal("object"),
+  required: z.array(z.string().min(1)).default([]),
+  properties: z.record(z.string().min(1), pluginFieldSchema).default({}),
+  additionalProperties: z.boolean().default(true),
+});
+
+export const pluginManifestSchema = z.object({
+  namespace: pluginNamespaceSchema,
+  schemaVersion,
+  payloadSchema: pluginPayloadSchemaSchema,
+});
+
+export const pluginMetaSchema = z.object({
+  namespace: pluginNamespaceSchema,
+  schemaVersion,
+  registeredAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+  registrationKind: z.enum(["static", "dynamic"]).default("dynamic"),
+});
+
 const PROPOSAL_STATUS_TRANSITIONS: Record<
   z.infer<typeof proposalStatusSchema>,
   Array<z.infer<typeof proposalStatusSchema>>
@@ -221,4 +258,7 @@ export type ProposalContent = z.infer<typeof proposalContentSchema>;
 export type ProposalMeta = z.infer<typeof proposalMetaSchema>;
 export type Proposal = z.infer<typeof proposalSchema>;
 export type DraftMeta = z.infer<typeof draftMetaSchema>;
+export type PluginManifest = z.infer<typeof pluginManifestSchema>;
+export type PluginMeta = z.infer<typeof pluginMetaSchema>;
+export type PluginPayloadSchema = z.infer<typeof pluginPayloadSchemaSchema>;
 export type RemEvent = z.infer<typeof remEventSchema>;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,6 +13,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "types": ["bun-types"],
+    "typeRoots": ["./node_modules", "./node_modules/@types"],
     "baseUrl": ".",
     "paths": {
       "@rem/shared": ["packages/shared/src/index.ts"],


### PR DESCRIPTION
## Summary
- refresh the REM UI, API, and CLI flows to align with the phase 2 contracts and fixtures
- extend core, sqlite, and filesystem store packages with new contract coverage and supporting tests
- add runbook and API/CLI reference docs to capture the new behaviors

## Testing
- Not run (not requested)