### PR TITLE
Enforce optional bearer auth for API

### DIFF
--- a/docs/api-cli-reference.md
+++ b/docs/api-cli-reference.md
@@ -6,6 +6,13 @@ Related docs:
 - Operational workflows: `docs/runbook.md`
 - Product requirements traceability: `docs/prd.md`
 
+## API auth
+
+- Optional bearer token auth is controlled by `REM_API_TOKEN`.
+- When `REM_API_TOKEN` is set, API requests must include:
+  - `Authorization: Bearer <token>`
+- When `REM_API_TOKEN` is unset, auth is not required.
+
 ## API endpoint matrix
 
 | Area | Method | Path | Purpose |
@@ -162,13 +169,14 @@ API errors use:
 ```json
 {
   "error": {
-    "code": "bad_request|not_found|invalid_transition|internal_error",
+    "code": "unauthorized|bad_request|not_found|invalid_transition|internal_error",
     "message": "..."
   }
 }
 ```
 
 Common cases:
+- `unauthorized`: missing or invalid bearer token when `REM_API_TOKEN` is configured
 - `bad_request`: schema/payload validation failures (including `PUT /notes/:id` id mismatch)
 - `not_found`: missing notes/proposals/drafts
 - `invalid_transition`: proposal status transition violations

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -22,6 +22,14 @@ bun run --cwd apps/ui dev
 
 Default API: `http://127.0.0.1:8787`
 
+Optional auth:
+
+```bash
+export REM_API_TOKEN="your-local-token"
+```
+
+When set, API requests must send `Authorization: Bearer <token>`.
+
 ## Core lifecycle (CLI)
 
 ```bash
@@ -58,33 +66,37 @@ bun run --cwd apps/cli src/index.ts status --json
 ```bash
 # Save note with plugin payload
 curl -X POST "http://127.0.0.1:8787/notes" \
+  -H "authorization: Bearer ${REM_API_TOKEN}" \
   -H "content-type: application/json" \
   -d @note.json
 
 # Explicit update for existing note id
 curl -X PUT "http://127.0.0.1:8787/notes/<note-id>" \
+  -H "authorization: Bearer ${REM_API_TOKEN}" \
   -H "content-type: application/json" \
   -d @note-update.json
 
 # Draft create/list/get
 curl -X POST "http://127.0.0.1:8787/drafts" \
+  -H "authorization: Bearer ${REM_API_TOKEN}" \
   -H "content-type: application/json" \
   -d @draft.json
-curl "http://127.0.0.1:8787/drafts?limit=20"
-curl "http://127.0.0.1:8787/drafts/<draft-id>"
+curl -H "authorization: Bearer ${REM_API_TOKEN}" "http://127.0.0.1:8787/drafts?limit=20"
+curl -H "authorization: Bearer ${REM_API_TOKEN}" "http://127.0.0.1:8787/drafts/<draft-id>"
 
 # Plugin registration/listing
 curl -X POST "http://127.0.0.1:8787/plugins/register" \
+  -H "authorization: Bearer ${REM_API_TOKEN}" \
   -H "content-type: application/json" \
   -d @plugin-register.json
-curl "http://127.0.0.1:8787/plugins?limit=50"
+curl -H "authorization: Bearer ${REM_API_TOKEN}" "http://127.0.0.1:8787/plugins?limit=50"
 
 # Search with tags/time filters
-curl "http://127.0.0.1:8787/search?q=deploy&tags=ops&noteTypes=task&pluginNamespaces=tasks&updatedSince=2026-02-01T00:00:00.000Z"
+curl -H "authorization: Bearer ${REM_API_TOKEN}" "http://127.0.0.1:8787/search?q=deploy&tags=ops&noteTypes=task&pluginNamespaces=tasks&updatedSince=2026-02-01T00:00:00.000Z"
 
 # Event history
-curl "http://127.0.0.1:8787/events?limit=50"
-curl "http://127.0.0.1:8787/events?entityKind=draft&since=2026-02-01T00:00:00.000Z"
+curl -H "authorization: Bearer ${REM_API_TOKEN}" "http://127.0.0.1:8787/events?limit=50"
+curl -H "authorization: Bearer ${REM_API_TOKEN}" "http://127.0.0.1:8787/events?entityKind=draft&since=2026-02-01T00:00:00.000Z"
 ```
 
 ## Proposal review workflow
@@ -128,6 +140,16 @@ Checks:
 - Plugin payload namespaces must be registered before note writes.
 - Plugin payload must satisfy manifest `payloadSchema` required fields/types.
 - Proposal content format must match payload shape.
+
+### Unauthorized API responses
+
+Symptoms:
+- API returns `{"error":{"code":"unauthorized","message":"Missing or invalid bearer token"}}`
+
+Checks:
+- Confirm `REM_API_TOKEN` is set for the running API process.
+- Include `Authorization: Bearer <token>` on requests.
+- Verify the token value exactly matches API process env.
 
 ### Missing target references
 


### PR DESCRIPTION
Summary
- add bearer token parsing and optional guard in `apps/api/src/index.ts` so the API respects `REM_API_TOKEN` when set and rejects unauthenticated calls
- document the new auth mode in `docs/api-cli-reference.md` and `docs/runbook.md`, including curl examples that pass the header and the new `unauthorized` error case
- extend the phase 2 API contracts test (`packages/core/src/phase2-contracts.test.ts`) to cover auth enforcement and to spin the server on a dynamic port with the token provided

Testing
- Not run (not requested)