### PR TITLE
Add theme mode settings

### DIFF
--- a/apps/ui/src/app.test.tsx
+++ b/apps/ui/src/app.test.tsx
@@ -11,6 +11,11 @@ describe("App", () => {
     expect(html).toContain('aria-label="Show panel"');
     expect(html).toContain("Workspace");
     expect(html).toContain("Autosave on. Waiting for edits.");
+    expect(html).toContain("Settings");
+    expect(html).toContain('aria-label="Theme mode"');
+    expect(html).toContain(">Light<");
+    expect(html).toContain(">Dark<");
+    expect(html).toContain(">System<");
     expect(html).toContain("Notes");
     expect(html).toContain("Search notes");
     expect(html).not.toContain("Plugin host");

--- a/apps/ui/src/styles.css
+++ b/apps/ui/src/styles.css
@@ -9,6 +9,41 @@
   --line-soft: #e4e1d8;
   --panel: #efede6;
   --accent: #21524a;
+  --accent-strong: #153f38;
+  --accent-contrast: #f3f7f6;
+  --surface-hover: #ebe8df;
+  --surface-input: #f8f6f0;
+  --surface-code: #f2efe8;
+  --placeholder: #938f87;
+  --placeholder-soft: #9f988f;
+  --focus-ring: rgba(33, 82, 74, 0.6);
+  --focus-border: rgba(33, 82, 74, 0.4);
+  --success: #20574e;
+  --error: #8a2f26;
+  --code-ink: #534f48;
+}
+
+:root[data-theme="dark"] {
+  --paper: #121310;
+  --paper-strong: #161814;
+  --ink: #ece9df;
+  --muted: #b1ab9f;
+  --line: #35382f;
+  --line-soft: #2a2d25;
+  --panel: #171915;
+  --accent: #5ca293;
+  --accent-strong: #468578;
+  --accent-contrast: #08120f;
+  --surface-hover: #20231d;
+  --surface-input: #1b1e18;
+  --surface-code: #141712;
+  --placeholder: #8f8a80;
+  --placeholder-soft: #847f74;
+  --focus-ring: rgba(92, 162, 147, 0.62);
+  --focus-border: rgba(92, 162, 147, 0.45);
+  --success: #78d3c3;
+  --error: #ff9a8f;
+  --code-ink: #d4cec1;
 }
 
 *,
@@ -72,7 +107,7 @@ body {
 }
 
 .menu-toggle:hover:not(:disabled) {
-  background: #ebe8df;
+  background: var(--surface-hover);
 }
 
 .meta-block {
@@ -95,7 +130,7 @@ body {
 }
 
 .meta-title-input::placeholder {
-  color: #938f87;
+  color: var(--placeholder);
 }
 
 .meta-title-input:focus {
@@ -161,17 +196,17 @@ body {
 
 .ghost-button:hover:not(:disabled),
 .icon-button:hover:not(:disabled) {
-  background: #ebe8df;
+  background: var(--surface-hover);
 }
 
 .solid-button {
-  border: 1px solid #21524a;
+  border: 1px solid var(--accent);
   background: var(--accent);
-  color: #f3f7f6;
+  color: var(--accent-contrast);
 }
 
 .solid-button:hover:not(:disabled) {
-  background: #153f38;
+  background: var(--accent-strong);
 }
 
 .ghost-button.small {
@@ -258,7 +293,7 @@ body {
   position: absolute;
   top: 0;
   left: 0;
-  color: #9f988f;
+  color: var(--placeholder-soft);
   font-style: italic;
   pointer-events: none;
   animation: cursor-blink 1.05s step-end infinite;
@@ -327,20 +362,26 @@ body {
   color: var(--muted);
 }
 
-.field input {
+.field input,
+.field select {
   width: 100%;
   border: 1px solid var(--line);
   border-radius: 0.66rem;
-  background: #f8f6f0;
+  background: var(--surface-input);
   color: var(--ink);
   padding: 0.54rem 0.6rem;
   font-size: 0.92rem;
   font-family: "Literata", "Baskerville", "Palatino Linotype", serif;
 }
 
-.field input:focus {
-  outline: 1px solid rgba(33, 82, 74, 0.6);
-  border-color: rgba(33, 82, 74, 0.4);
+.field select {
+  cursor: pointer;
+}
+
+.field input:focus,
+.field select:focus {
+  outline: 1px solid var(--focus-ring);
+  border-color: var(--focus-border);
 }
 
 .save-state {
@@ -355,11 +396,11 @@ body {
 }
 
 .save-state-success {
-  color: #20574e;
+  color: var(--success);
 }
 
 .save-state-error {
-  color: #8a2f26;
+  color: var(--error);
 }
 
 .panel-empty {
@@ -389,7 +430,7 @@ body {
   width: 100%;
   border: 1px solid var(--line);
   border-radius: 0.68rem;
-  background: #f8f6f0;
+  background: var(--surface-input);
   color: var(--ink);
   text-align: left;
   padding: 0.46rem 0.52rem;
@@ -416,7 +457,7 @@ body {
   border: 1px solid var(--line);
   border-radius: 0.7rem;
   padding: 0.55rem;
-  background: #f8f6f0;
+  background: var(--surface-input);
 }
 
 .proposal-detail p {
@@ -437,7 +478,7 @@ body {
   overflow: auto;
   border: 1px solid var(--line-soft);
   border-radius: 0.6rem;
-  background: #f2efe8;
+  background: var(--surface-code);
   padding: 0.5rem;
   font-size: 0.69rem;
   line-height: 1.35;
@@ -454,7 +495,7 @@ body {
 .command-list li {
   border: 1px solid var(--line-soft);
   border-radius: 0.65rem;
-  background: #f8f6f0;
+  background: var(--surface-input);
   padding: 0.44rem 0.5rem;
 }
 
@@ -479,7 +520,7 @@ body {
 .command-list code {
   margin-top: 0.2rem;
   display: block;
-  color: #534f48;
+  color: var(--code-ink);
   font-size: 0.67rem;
   white-space: nowrap;
   overflow-x: auto;


### PR DESCRIPTION
Summary
- add theme-mode state management, system preference tracking, and persistence in the UI app
- wire the document root to the resolved theme and expose a settings dropdown with light/dark/system options
- extend the styles to use CSS variables so both palettes respond to the selected mode
Testing
- Not run (not requested)