### PR TITLE
fix(ci): update macOS x64 runner label for release workflow

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -65,7 +65,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-13
+          # macOS 13 was retired in Dec 2025; use the current Intel runner label.
+          - runner: macos-15-intel
             arch: x64
           - runner: macos-14
             arch: arm64


### PR DESCRIPTION
## Summary
- replace retired `macos-13` standard runner in release matrix with `macos-15-intel` for x64 builds
- keep arm64 build on `macos-14`
- add inline note documenting the retirement context

## Why
The `Release macOS` workflow run https://github.com/ejohane/rem/actions/runs/21863566655 failed because the x64 job resolved to unsupported configuration `macos-13-us-default` after macOS 13 retirement.
