### PR TITLE
Add CLI commands for bundled agent skill installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ bun run --cwd apps/cli src/index.ts search "deploy" \
   --json
 bun run --cwd apps/cli src/index.ts status --json
 bun run --cwd apps/cli src/index.ts migrate sections --json
+
+# Install bundled canned agent skill for rem CLI memory workflows
+bun run --cwd apps/cli src/index.ts skill list --json
+bun run --cwd apps/cli src/index.ts skill install rem-cli-memory --json
 ```
 
 ## API proposal endpoints

--- a/apps/cli/src/canned-skills.ts
+++ b/apps/cli/src/canned-skills.ts
@@ -1,0 +1,161 @@
+import type { PluginManifest } from "@rem/schemas";
+
+export interface CannedSkillDefinition {
+  id: string;
+  name: string;
+  description: string;
+  pluginManifest: PluginManifest;
+  note: {
+    id: string;
+    title: string;
+    noteType: string;
+    tags: string[];
+    lexicalState: unknown;
+    payload: Record<string, unknown>;
+  };
+}
+
+function heading(level: 1 | 2 | 3 | 4 | 5 | 6, text: string): Record<string, unknown> {
+  return {
+    type: "heading",
+    tag: `h${level}`,
+    version: 1,
+    children: [
+      {
+        type: "text",
+        version: 1,
+        text,
+      },
+    ],
+  };
+}
+
+function paragraph(text: string): Record<string, unknown> {
+  return {
+    type: "paragraph",
+    version: 1,
+    children: [
+      {
+        type: "text",
+        version: 1,
+        text,
+      },
+    ],
+  };
+}
+
+const agentSkillsManifest: PluginManifest = {
+  namespace: "agent-skills",
+  schemaVersion: "v1",
+  payloadSchema: {
+    type: "object",
+    required: ["skillId", "summary", "invokeWhen", "coreCommands"],
+    properties: {
+      skillId: { type: "string" },
+      summary: { type: "string" },
+      invokeWhen: { type: "array", items: { type: "string" } },
+      avoidWhen: { type: "array", items: { type: "string" } },
+      coreCommands: { type: "array", items: { type: "string" } },
+      workflow: { type: "array", items: { type: "string" } },
+    },
+    additionalProperties: false,
+  },
+};
+
+const remCliMemorySkill: CannedSkillDefinition = {
+  id: "rem-cli-memory",
+  name: "REM CLI Memory",
+  description:
+    "Agent skill for when to use rem CLI and how to run memory-safe note/proposal/plugin workflows.",
+  pluginManifest: agentSkillsManifest,
+  note: {
+    id: "skill-rem-cli-memory",
+    title: "Skill: REM CLI Memory Workflow",
+    noteType: "agent-skill",
+    tags: ["agent", "skill", "memory", "cli", "rem"],
+    lexicalState: {
+      root: {
+        type: "root",
+        version: 1,
+        children: [
+          heading(1, "REM CLI Memory Workflow"),
+          paragraph(
+            "Use this skill when an agent needs durable memory operations in rem (notes, sections, proposals, plugins, and status/event checks).",
+          ),
+          heading(2, "Invoke When"),
+          paragraph(
+            "You need to capture or update memory in the vault, inspect prior context, or perform proposal-based edits instead of free-form file changes.",
+          ),
+          paragraph(
+            "You need deterministic retrieval via search filters like tags, note types, plugin namespaces, or time windows.",
+          ),
+          heading(2, "Avoid When"),
+          paragraph(
+            "The task is unrelated to memory management in rem, such as browser automation, external integrations, or non-vault project edits.",
+          ),
+          heading(2, "Core Commands"),
+          paragraph("rem notes save --input <path> --json"),
+          paragraph("rem sections list --note <note-id> --json"),
+          paragraph(
+            'rem proposals create --note <note-id> --section <section-id> --text "..." --json',
+          ),
+          paragraph("rem proposals list --status open --json"),
+          paragraph("rem proposals accept <proposal-id> --json"),
+          paragraph(
+            'rem search "<query>" --tags <csv> --note-types <csv> --plugin-namespaces <csv> --json',
+          ),
+          paragraph("rem status --json"),
+          heading(2, "Recommended Flow"),
+          paragraph("1. Search for existing memory before writing."),
+          paragraph("2. Save or update notes with structured metadata."),
+          paragraph(
+            "3. Use section-targeted proposals for edits that should be reviewable or reversible.",
+          ),
+          paragraph(
+            "4. Verify system health/events when debugging stale results or sync concerns.",
+          ),
+        ],
+      },
+    },
+    payload: {
+      skillId: "rem-cli-memory",
+      summary:
+        "Use rem CLI for durable memory creation, retrieval, and proposal-based edits in agent workflows.",
+      invokeWhen: [
+        "Need to create or update memory notes in rem.",
+        "Need filtered retrieval using tags, note types, plugin namespaces, or time windows.",
+        "Need section-targeted proposal review instead of direct note overwrite.",
+        "Need event and status visibility while debugging memory pipelines.",
+      ],
+      avoidWhen: [
+        "Task does not involve rem vault data.",
+        "Task is primarily browser or external system automation.",
+      ],
+      coreCommands: [
+        "rem notes save --input <path> --json",
+        "rem sections list --note <note-id> --json",
+        'rem proposals create --note <note-id> --section <section-id> --text "..." --json',
+        "rem proposals list --status open --json",
+        "rem proposals accept <proposal-id> --json",
+        'rem search "<query>" --tags <csv> --note-types <csv> --plugin-namespaces <csv> --json',
+        "rem status --json",
+      ],
+      workflow: [
+        "Search existing memory first.",
+        "Write or update canonical notes with metadata.",
+        "Use proposals for section-scoped updates.",
+        "Review status/events to confirm indexing health.",
+      ],
+    },
+  },
+};
+
+const cannedSkills: CannedSkillDefinition[] = [remCliMemorySkill];
+
+export function listCannedSkills(): CannedSkillDefinition[] {
+  return cannedSkills;
+}
+
+export function getCannedSkill(skillId: string): CannedSkillDefinition | undefined {
+  return cannedSkills.find((skill) => skill.id === skillId);
+}

--- a/docs/api-cli-reference.md
+++ b/docs/api-cli-reference.md
@@ -96,6 +96,8 @@ Related docs:
 | Proposals | `rem proposals create/list/get/accept/reject ... --json` | Proposal lifecycle |
 | Plugins | `rem plugin register --manifest <path> --json` | Register plugin |
 | Plugins | `rem plugin list --limit <n> --json` | List plugins |
+| Skills | `rem skill list --json` | List bundled canned skills |
+| Skills | `rem skill install <skill-id> --json` | Install canned skill into local vault |
 | Events | `rem events tail --limit <n> --json` | Recent events |
 | Events | `rem events list --since <iso> --entity-kind <kind> --json` | Filtered events |
 | Migration | `rem migrate sections --json` | Backfill durable section identity metadata |
@@ -150,6 +152,13 @@ bun run --cwd apps/cli src/index.ts search "deploy" \
   --created-since 2026-02-01T00:00:00.000Z \
   --updated-since 2026-02-01T00:00:00.000Z \
   --json
+```
+
+### Install bundled rem CLI memory skill (CLI)
+
+```bash
+bun run --cwd apps/cli src/index.ts skill list --json
+bun run --cwd apps/cli src/index.ts skill install rem-cli-memory --json
 ```
 
 ### Run section identity migration (CLI)

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -38,6 +38,10 @@ bun run --cwd apps/cli src/index.ts notes save --input ./note.json --actor-kind 
 bun run --cwd apps/cli src/index.ts plugin register --manifest ./plugin-manifest.json --json
 bun run --cwd apps/cli src/index.ts plugin list --json
 
+# Discover/install bundled canned skills (installs into vault)
+bun run --cwd apps/cli src/index.ts skill list --json
+bun run --cwd apps/cli src/index.ts skill install rem-cli-memory --json
+
 # Search with metadata filters
 bun run --cwd apps/cli src/index.ts search "deploy" \
   --tags ops \
@@ -143,6 +147,7 @@ Symptoms:
 Checks:
 - Plugin payload namespaces must be registered before note writes.
 - Plugin payload must satisfy manifest `payloadSchema` required fields/types.
+- `skill install` registers the `agent-skills` plugin automatically before writing the skill note.
 - Proposal content format must match payload shape.
 - Agent actors must include an id when using `kind: "agent"`.
 


### PR DESCRIPTION
Summary
- add canned skill data plus CLI commands so agents can discover and install the rem CLI memory skill
- update docs/runbook/README with the new skill workflow and reference in the CLI reference
- cover listing/installing in e2e tests and ensure plugin registration plus re-install stability

Testing
- Not run (not requested)