### PR TITLE
Add macOS install script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,37 @@ Package output:
 - `dist/macos/rem-<version>-macos-<arch>.tar.gz`
 - `dist/macos/rem-<version>-macos-<arch>.tar.gz.sha256`
 
+Quick install from a release tarball:
+
+```bash
+tar -xzf rem-<version>-macos-<arch>.tar.gz
+cd rem-<version>-macos-<arch>
+./install.sh
+rem app
+```
+
 Package contents:
 - `rem` (CLI + `rem app` launcher)
 - `rem-api` (API server binary)
 - `ui-dist/` (built UI assets)
+- `install.sh` (installs rem to `/opt/rem` and creates `/usr/local/bin/rem`)
 
 Run full REM from the package directory:
 
 ```bash
 ./rem app
+```
+
+Install rem system-wide from the package directory:
+
+```bash
+./install.sh
+```
+
+Install without sudo into your home directory:
+
+```bash
+./install.sh --local
 ```
 
 ## Release versioning

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -218,11 +218,18 @@ Artifact layout:
 - `rem` compiled CLI executable
 - `rem-api` compiled API executable
 - `ui-dist/` static UI build
+- `install.sh` installer script for `/opt/rem` + `/usr/local/bin/rem`
 
 Start full REM from the extracted package:
 
 ```bash
 ./rem app
+```
+
+Install from the extracted package:
+
+```bash
+./install.sh
 ```
 
 ## Release process (semantic versioning)

--- a/scripts/install-macos.sh
+++ b/scripts/install-macos.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_DIR="$SCRIPT_DIR"
+
+INSTALL_DIR="${REM_INSTALL_DIR:-/opt/rem}"
+BIN_DIR="${REM_BIN_DIR:-/usr/local/bin}"
+
+usage() {
+  cat <<'EOF'
+Install rem from an extracted macOS package directory.
+
+Usage:
+  ./install.sh [--install-dir <path>] [--bin-dir <path>] [--local]
+
+Options:
+  --install-dir <path>  Install binaries/assets into this directory.
+                        Default: /opt/rem (or $REM_INSTALL_DIR)
+  --bin-dir <path>      Write the launcher script to this directory.
+                        Default: /usr/local/bin (or $REM_BIN_DIR)
+  --local               Install without sudo into:
+                        install dir: $HOME/.local/share/rem
+                        bin dir:     $HOME/.local/bin
+  -h, --help            Show this help message.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --install-dir)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --install-dir" >&2
+        exit 1
+      fi
+      INSTALL_DIR="$2"
+      shift 2
+      ;;
+    --bin-dir)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --bin-dir" >&2
+        exit 1
+      fi
+      BIN_DIR="$2"
+      shift 2
+      ;;
+    --local)
+      INSTALL_DIR="$HOME/.local/share/rem"
+      BIN_DIR="$HOME/.local/bin"
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+for required in "rem" "rem-api" "ui-dist/index.html"; do
+  if [[ ! -e "$PACKAGE_DIR/$required" ]]; then
+    echo "Expected package file missing: $PACKAGE_DIR/$required" >&2
+    exit 1
+  fi
+done
+
+mkdir -p "$INSTALL_DIR" "$BIN_DIR"
+
+cp "$PACKAGE_DIR/rem" "$INSTALL_DIR/rem"
+cp "$PACKAGE_DIR/rem-api" "$INSTALL_DIR/rem-api"
+rm -rf "$INSTALL_DIR/ui-dist"
+cp -R "$PACKAGE_DIR/ui-dist" "$INSTALL_DIR/ui-dist"
+if [[ -f "$PACKAGE_DIR/README.md" ]]; then
+  cp "$PACKAGE_DIR/README.md" "$INSTALL_DIR/README.md"
+fi
+
+chmod +x "$INSTALL_DIR/rem" "$INSTALL_DIR/rem-api"
+
+LAUNCHER_PATH="$BIN_DIR/rem"
+cat >"$LAUNCHER_PATH" <<EOF
+#!/bin/sh
+export REM_API_BINARY="$INSTALL_DIR/rem-api"
+export REM_UI_DIST="$INSTALL_DIR/ui-dist"
+exec "$INSTALL_DIR/rem" "\$@"
+EOF
+chmod +x "$LAUNCHER_PATH"
+
+if command -v xattr >/dev/null 2>&1; then
+  xattr -dr com.apple.quarantine "$INSTALL_DIR" 2>/dev/null || true
+  xattr -d com.apple.quarantine "$LAUNCHER_PATH" 2>/dev/null || true
+fi
+
+printf 'Installed rem:\n- install dir: %s\n- launcher: %s\n\n' "$INSTALL_DIR" "$LAUNCHER_PATH"
+printf 'Run: %s app\n' "$LAUNCHER_PATH"

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -42,6 +42,8 @@ bun build --compile --outfile "$PACKAGE_DIR/rem-api" apps/api/src/index.ts
 
 cp -R apps/ui/dist "$PACKAGE_DIR/ui-dist"
 cp README.md "$PACKAGE_DIR/README.md"
+cp scripts/install-macos.sh "$PACKAGE_DIR/install.sh"
+chmod +x "$PACKAGE_DIR/install.sh"
 
 "$PACKAGE_DIR/rem" --help >/dev/null
 


### PR DESCRIPTION
Summary
- add `install.sh` to packages so macOS releases include an installer that copies binaries/assets and writes a launcher plus quarantine cleanup (`scripts/install-macos.sh`)
- document quick install steps and install paths in `README.md` and `docs/runbook.md`, including `--local` mode and default install/bin dirs
- ensure packaging copies the installer into the tarball and stays executable (`scripts/package-macos.sh`)

Testing
- Not run (not requested)