### PR TITLE
Remove dedicated plugin UI surfaces

### DIFF
--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -38,27 +38,7 @@ import {
   parseTags,
   plainTextToLexicalState,
 } from "./lexical";
-import {
-  type HostedPluginCommand,
-  type PluginCommandSource,
-  buildPluginCommandInvocationPayload,
-  deriveHostedPluginCommands,
-} from "./plugin-commands";
-import {
-  type PluginPanelSource,
-  type PluginPanelsBySlot,
-  deriveHostedPluginPanels,
-  groupHostedPluginPanelsBySlot,
-} from "./plugin-panels";
-import {
-  type CanonicalNoteRecord,
-  type ProposalContentRecord,
-  type ProposalEntityReference,
-  collectProposalEntityReferences,
-  extractSectionContext,
-  formatEntityReferenceLabel,
-  summarizeEntityContext,
-} from "./proposals";
+import type { CanonicalNoteRecord } from "./proposals";
 
 const API_BASE_URL = import.meta.env.VITE_REM_API_BASE_URL ?? "http://127.0.0.1:8787";
 const AUTOSAVE_DELAY_MS = 1200;
@@ -122,52 +102,10 @@ type NoteEventRecord = {
 type CanonicalNoteResponse = {
   noteId: string;
   lexicalState: CanonicalNoteRecord["lexicalState"];
-  sectionIndex: CanonicalNoteRecord["sectionIndex"];
   meta: {
     title: string;
     tags: string[];
   };
-};
-
-type ProposalSourceRecord = {
-  proposal: {
-    id: string;
-    status: "open" | "accepted" | "rejected" | "superseded";
-    target: {
-      noteId: string;
-      sectionId: string;
-      fallbackPath?: string[];
-    };
-    proposalType: "replace_section" | "annotate";
-  };
-  content: ProposalContentRecord;
-};
-
-type ProposalReviewEntityContext = {
-  reference: ProposalEntityReference;
-  summary: string;
-  unresolved: boolean;
-};
-
-type ProposalReviewContext = {
-  proposalId: string;
-  proposalType: ProposalSourceRecord["proposal"]["proposalType"];
-  sectionId: string;
-  fallbackPath: string[];
-  sectionContext: string | null;
-  entities: ProposalReviewEntityContext[];
-};
-
-type ProposalEntityLookupResponse = {
-  entity: {
-    data: Record<string, unknown>;
-  };
-};
-
-const EMPTY_PLUGIN_PANELS: PluginPanelsBySlot = {
-  sidebar: [],
-  toolbar: [],
-  proposalReview: [],
 };
 
 type StoreRootConfigResponse = {
@@ -193,10 +131,6 @@ function formatModifiedAt(iso: string): string {
     hour: "2-digit",
     minute: "2-digit",
   });
-}
-
-function proposalEntityReferenceKey(reference: ProposalEntityReference): string {
-  return `${reference.namespace}:${reference.entityType}:${reference.entityId}`;
 }
 
 function isThemePreference(value: string): value is ThemePreference {
@@ -409,23 +343,6 @@ export function App() {
     kind: "idle",
     message: "Loading notes...",
   });
-  const [pluginPanelsBySlot, setPluginPanelsBySlot] =
-    useState<PluginPanelsBySlot>(EMPTY_PLUGIN_PANELS);
-  const [pluginPanelsState, setPluginPanelsState] = useState<SaveState>({
-    kind: "idle",
-    message: "Loading plugin panels...",
-  });
-  const [pluginCommands, setPluginCommands] = useState<HostedPluginCommand[]>([]);
-  const [pluginCommandsState, setPluginCommandsState] = useState<SaveState>({
-    kind: "idle",
-    message: "Loading plugin commands...",
-  });
-  const [proposalReviewContexts, setProposalReviewContexts] = useState<ProposalReviewContext[]>([]);
-  const [proposalReviewState, setProposalReviewState] = useState<SaveState>({
-    kind: "idle",
-    message: "Select a saved note to inspect proposal context.",
-  });
-  const [runningPluginCommandKey, setRunningPluginCommandKey] = useState<string | null>(null);
   const [activePage, setActivePage] = useState<"editor" | "settings">("editor");
   const [team, setTeam] = useState("Core");
   const [themePreference, setThemePreference] = useState<ThemePreference>("dark");
@@ -636,233 +553,6 @@ export function App() {
     }
   }, []);
 
-  const refreshPluginPanels = useCallback(async (): Promise<void> => {
-    setPluginPanelsState({
-      kind: "saving",
-      message: "Loading plugin panels...",
-    });
-    setPluginCommandsState({
-      kind: "saving",
-      message: "Loading plugin commands...",
-    });
-
-    try {
-      const response = await fetch(`${API_BASE_URL}/plugins?limit=200`);
-      if (!response.ok) {
-        throw new Error(`Failed loading plugin panels (${response.status})`);
-      }
-
-      const payload = (await response.json()) as Array<PluginPanelSource & PluginCommandSource>;
-      const hostedPanels = deriveHostedPluginPanels(payload);
-      const hostedCommands = deriveHostedPluginCommands(payload);
-      setPluginPanelsBySlot(groupHostedPluginPanelsBySlot(hostedPanels));
-      setPluginCommands(hostedCommands);
-      setPluginPanelsState({
-        kind: "success",
-        message:
-          hostedPanels.length === 0
-            ? "No plugin panels available."
-            : `Loaded ${hostedPanels.length} plugin panels.`,
-      });
-      setPluginCommandsState({
-        kind: "success",
-        message:
-          hostedCommands.length === 0
-            ? "No plugin commands available."
-            : `Loaded ${hostedCommands.length} plugin commands.`,
-      });
-    } catch (error) {
-      setPluginPanelsBySlot(EMPTY_PLUGIN_PANELS);
-      setPluginCommands([]);
-      setPluginPanelsState({
-        kind: "error",
-        message: error instanceof Error ? error.message : "Failed loading plugin panels.",
-      });
-      setPluginCommandsState({
-        kind: "error",
-        message: error instanceof Error ? error.message : "Failed loading plugin commands.",
-      });
-    }
-  }, []);
-
-  const refreshProposalReview = useCallback(async (): Promise<void> => {
-    const targetNoteId = noteId;
-    if (!targetNoteId) {
-      setProposalReviewContexts([]);
-      setProposalReviewState({
-        kind: "idle",
-        message: "Select a saved note to inspect proposal context.",
-      });
-      return;
-    }
-
-    setProposalReviewState({
-      kind: "saving",
-      message: `Loading proposal context for ${targetNoteId.slice(0, 8)}...`,
-    });
-
-    try {
-      const [proposalResponse, noteResponse] = await Promise.all([
-        fetch(`${API_BASE_URL}/proposals?status=open`),
-        fetch(`${API_BASE_URL}/notes/${targetNoteId}`),
-      ]);
-
-      if (!proposalResponse.ok) {
-        throw new Error(`Failed loading proposals (${proposalResponse.status})`);
-      }
-      if (!noteResponse.ok) {
-        throw new Error(`Failed loading note context (${noteResponse.status})`);
-      }
-
-      const proposalPayload = (await proposalResponse.json()) as ProposalSourceRecord[];
-      const notePayload = (await noteResponse.json()) as CanonicalNoteResponse;
-      const openProposals = proposalPayload
-        .filter((record) => {
-          return (
-            record.proposal.status === "open" && record.proposal.target.noteId === targetNoteId
-          );
-        })
-        .sort((left, right) => left.proposal.id.localeCompare(right.proposal.id));
-
-      if (openProposals.length === 0) {
-        if (noteIdRef.current !== targetNoteId) {
-          return;
-        }
-
-        setProposalReviewContexts([]);
-        setProposalReviewState({
-          kind: "success",
-          message: "No open proposals for this note.",
-        });
-        return;
-      }
-
-      const proposalContexts = openProposals.map((record) => {
-        const sectionContext = extractSectionContext(
-          notePayload,
-          record.proposal.target.sectionId,
-          record.proposal.target.fallbackPath,
-        );
-        const references = collectProposalEntityReferences({
-          sectionContext,
-          proposalContent: record.content,
-        });
-
-        return {
-          proposalId: record.proposal.id,
-          proposalType: record.proposal.proposalType,
-          sectionId: record.proposal.target.sectionId,
-          fallbackPath: record.proposal.target.fallbackPath ?? [],
-          sectionContext,
-          references,
-        };
-      });
-
-      const uniqueReferences = new Map<string, ProposalEntityReference>();
-      for (const proposalContext of proposalContexts) {
-        for (const reference of proposalContext.references) {
-          uniqueReferences.set(proposalEntityReferenceKey(reference), reference);
-        }
-      }
-
-      const contextByEntityKey = new Map<string, ProposalReviewEntityContext>();
-      await Promise.all(
-        [...uniqueReferences.values()].map(async (reference) => {
-          const key = proposalEntityReferenceKey(reference);
-          const referenceLabel = formatEntityReferenceLabel(reference);
-
-          try {
-            const response = await fetch(
-              `${API_BASE_URL}/entities/${encodeURIComponent(reference.namespace)}/${encodeURIComponent(reference.entityType)}/${encodeURIComponent(reference.entityId)}`,
-            );
-
-            if (response.status === 404) {
-              contextByEntityKey.set(key, {
-                reference,
-                summary: `${referenceLabel} (missing entity)`,
-                unresolved: true,
-              });
-              return;
-            }
-
-            if (!response.ok) {
-              contextByEntityKey.set(key, {
-                reference,
-                summary: `${referenceLabel} (entity lookup failed: ${response.status})`,
-                unresolved: true,
-              });
-              return;
-            }
-
-            const payload = (await response.json()) as ProposalEntityLookupResponse;
-            const entityData = payload.entity?.data;
-            if (!entityData || typeof entityData !== "object") {
-              contextByEntityKey.set(key, {
-                reference,
-                summary: `${referenceLabel} (entity payload missing data)`,
-                unresolved: true,
-              });
-              return;
-            }
-
-            contextByEntityKey.set(key, {
-              reference,
-              summary: summarizeEntityContext(reference, entityData),
-              unresolved: false,
-            });
-          } catch {
-            contextByEntityKey.set(key, {
-              reference,
-              summary: `${referenceLabel} (entity lookup failed)`,
-              unresolved: true,
-            });
-          }
-        }),
-      );
-
-      if (noteIdRef.current !== targetNoteId) {
-        return;
-      }
-
-      const hydratedContexts: ProposalReviewContext[] = proposalContexts.map((proposalContext) => {
-        const entities = proposalContext.references.map((reference) => {
-          return (
-            contextByEntityKey.get(proposalEntityReferenceKey(reference)) ?? {
-              reference,
-              summary: `${formatEntityReferenceLabel(reference)} (entity context unavailable)`,
-              unresolved: true,
-            }
-          );
-        });
-
-        return {
-          proposalId: proposalContext.proposalId,
-          proposalType: proposalContext.proposalType,
-          sectionId: proposalContext.sectionId,
-          fallbackPath: proposalContext.fallbackPath,
-          sectionContext: proposalContext.sectionContext,
-          entities,
-        };
-      });
-
-      setProposalReviewContexts(hydratedContexts);
-      setProposalReviewState({
-        kind: "success",
-        message: `Loaded context for ${hydratedContexts.length} open proposal${hydratedContexts.length === 1 ? "" : "s"}.`,
-      });
-    } catch (error) {
-      if (noteIdRef.current !== targetNoteId) {
-        return;
-      }
-
-      setProposalReviewContexts([]);
-      setProposalReviewState({
-        kind: "error",
-        message: error instanceof Error ? error.message : "Failed loading proposal context.",
-      });
-    }
-  }, [noteId]);
-
   const applyStoreRootConfig = useCallback(
     async (nextStoreRoot: string): Promise<void> => {
       setStoreRootState({
@@ -898,7 +588,6 @@ export function App() {
           message: formatStoreRootMessage(payload),
         });
         await refreshNotes();
-        await refreshPluginPanels();
       } catch (error) {
         setStoreRootState({
           kind: "error",
@@ -906,7 +595,7 @@ export function App() {
         });
       }
     },
-    [refreshNotes, refreshPluginPanels],
+    [refreshNotes],
   );
 
   const saveStoreRootConfig = useCallback(async (): Promise<void> => {
@@ -924,14 +613,6 @@ export function App() {
   useEffect(() => {
     void refreshNotes();
   }, [refreshNotes]);
-
-  useEffect(() => {
-    void refreshPluginPanels();
-  }, [refreshPluginPanels]);
-
-  useEffect(() => {
-    void refreshProposalReview();
-  }, [refreshProposalReview]);
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent): void => {
@@ -993,72 +674,6 @@ export function App() {
       });
     }
   }, []);
-
-  const runPluginCommand = useCallback(
-    async (command: HostedPluginCommand): Promise<void> => {
-      const commandKey = `${command.namespace}:${command.actionId}`;
-      if (!command.allowed) {
-        setPluginCommandsState({
-          kind: "error",
-          message: `Command ${command.namespace}/${command.actionId} blocked: missing permissions ${command.missingPermissions.join(", ")}`,
-        });
-        return;
-      }
-
-      setRunningPluginCommandKey(commandKey);
-      setPluginCommandsState({
-        kind: "saving",
-        message: `Running ${command.namespace}/${command.actionId}...`,
-      });
-
-      try {
-        const response = await fetch(
-          `${API_BASE_URL}/plugins/${command.namespace}/actions/${command.actionId}`,
-          {
-            method: "POST",
-            headers: {
-              "content-type": "application/json",
-            },
-            body: JSON.stringify(
-              buildPluginCommandInvocationPayload({
-                noteId,
-                title,
-                tags: parsedTags,
-                plainText: lexicalStateToPlainText(editorState),
-              }),
-            ),
-          },
-        );
-
-        if (!response.ok) {
-          const payload = (await response.json().catch(() => null)) as {
-            error?: { message?: string };
-          } | null;
-          throw new Error(
-            payload?.error?.message ??
-              `Command failed (${response.status}) for ${command.namespace}/${command.actionId}`,
-          );
-        }
-
-        const payload = (await response.json()) as {
-          requestId?: string;
-        };
-        setPluginCommandsState({
-          kind: "success",
-          message: `Ran ${command.namespace}/${command.actionId}${payload.requestId ? ` (${payload.requestId.slice(0, 8)})` : ""}`,
-        });
-        await Promise.all([refreshNotes(), refreshProposalReview()]);
-      } catch (error) {
-        setPluginCommandsState({
-          kind: "error",
-          message: error instanceof Error ? error.message : "Plugin command failed.",
-        });
-      } finally {
-        setRunningPluginCommandKey(null);
-      }
-    },
-    [editorState, noteId, parsedTags, refreshNotes, refreshProposalReview, title],
-  );
 
   const saveNote = useCallback(
     async (origin: "auto" | "manual"): Promise<void> => {
@@ -1242,33 +857,6 @@ export function App() {
             )}
           </div>
 
-          <div className="plugin-slot plugin-slot-sidebar" aria-label="Plugin sidebar panels">
-            <div className="panel-tree-head">
-              <p>Plugin Sidebar Panels</p>
-            </div>
-            <p className="panel-meta-line panel-meta-line-muted">{pluginPanelsState.message}</p>
-            {pluginPanelsBySlot.sidebar.length === 0 ? (
-              <p className="panel-empty">No sidebar plugin panels.</p>
-            ) : (
-              <ul className="plugin-panel-list" aria-label="Sidebar plugin panels">
-                {pluginPanelsBySlot.sidebar.map((panel) => (
-                  <li key={`${panel.namespace}:${panel.panelId}`} className="plugin-panel-card">
-                    <p>
-                      {panel.namespace}/{panel.panelId}
-                    </p>
-                    <strong>{panel.title}</strong>
-                    <span>Isolated declarative panel (runtime disabled)</span>
-                    {panel.requiredPermissions.length > 0 ? (
-                      <span>Permissions: {panel.requiredPermissions.join(", ")}</span>
-                    ) : (
-                      <span>Permissions: none declared</span>
-                    )}
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
-
           <Button
             type="button"
             variant="subtle"
@@ -1314,66 +902,7 @@ export function App() {
                     </span>
                   </p>
                 </div>
-
-                <div className="plugin-toolbar-slot" aria-label="Plugin toolbar panels">
-                  {pluginPanelsBySlot.toolbar.length === 0 ? (
-                    <p>No toolbar plugin panels.</p>
-                  ) : (
-                    pluginPanelsBySlot.toolbar.map((panel) => (
-                      <div
-                        key={`${panel.namespace}:${panel.panelId}`}
-                        className="plugin-toolbar-chip"
-                        title={`Isolated declarative panel for ${panel.namespace}/${panel.panelId}`}
-                      >
-                        <span>{panel.title}</span>
-                        <small>{panel.namespace}</small>
-                      </div>
-                    ))
-                  )}
-                </div>
               </header>
-
-              <section className="plugin-command-surface" aria-label="Plugin commands">
-                <header>
-                  <h2>Plugin Commands</h2>
-                  <p>{pluginCommandsState.message}</p>
-                </header>
-                {pluginCommands.length === 0 ? (
-                  <p className="plugin-command-empty">No plugin commands.</p>
-                ) : (
-                  <ul className="plugin-command-list">
-                    {pluginCommands.map((command) => {
-                      const commandKey = `${command.namespace}:${command.actionId}`;
-                      const disabled =
-                        !command.allowed ||
-                        runningPluginCommandKey === commandKey ||
-                        pluginCommandsState.kind === "saving";
-
-                      return (
-                        <li key={commandKey}>
-                          <Button
-                            type="button"
-                            size="sm"
-                            variant={command.allowed ? "subtle" : "ghost"}
-                            disabled={disabled}
-                            onClick={() => void runPluginCommand(command)}
-                          >
-                            {command.title}
-                          </Button>
-                          <span>
-                            {command.namespace}/{command.actionId}
-                          </span>
-                          {command.allowed ? (
-                            <small>allowed</small>
-                          ) : (
-                            <small>blocked: {command.missingPermissions.join(", ")}</small>
-                          )}
-                        </li>
-                      );
-                    })}
-                  </ul>
-                )}
-              </section>
 
               <main className="canvas" aria-label="Writing canvas">
                 <div className="canvas-frame">
@@ -1383,84 +912,6 @@ export function App() {
                     onStateChange={setEditorState}
                   />
                 </div>
-
-                <section className="proposal-plugin-slot" aria-label="Proposal review panels">
-                  <header>
-                    <h2>Proposal Review Panels</h2>
-                    <p>Entity context is resolved from open proposals and plugin entities.</p>
-                  </header>
-                  <section
-                    className="proposal-review-context"
-                    aria-label="Entity-aware proposal context"
-                  >
-                    <header>
-                      <h3>Entity-Aware Context</h3>
-                      <p>{proposalReviewState.message}</p>
-                    </header>
-                    {proposalReviewContexts.length === 0 ? (
-                      <p className="proposal-review-empty">
-                        No entity-aware proposal context for this note.
-                      </p>
-                    ) : (
-                      <ul className="proposal-review-list">
-                        {proposalReviewContexts.map((proposalContext) => (
-                          <li key={proposalContext.proposalId} className="proposal-review-card">
-                            <div className="proposal-review-card-head">
-                              <strong>{proposalContext.proposalId}</strong>
-                              <span>{proposalContext.proposalType}</span>
-                            </div>
-                            <p className="proposal-review-target">
-                              section <code>{proposalContext.sectionId}</code>
-                              {proposalContext.fallbackPath.length > 0
-                                ? ` (${proposalContext.fallbackPath.join(" > ")})`
-                                : ""}
-                            </p>
-                            <p className="proposal-review-section">
-                              {proposalContext.sectionContext ?? "Section context unavailable."}
-                            </p>
-                            {proposalContext.entities.length === 0 ? (
-                              <p className="proposal-review-entity-empty">
-                                No person/meeting references found in proposal or section context.
-                              </p>
-                            ) : (
-                              <ul className="proposal-review-entities">
-                                {proposalContext.entities.map((entityContext) => (
-                                  <li
-                                    key={proposalEntityReferenceKey(entityContext.reference)}
-                                    className={
-                                      entityContext.unresolved
-                                        ? "proposal-review-entity proposal-review-entity-unresolved"
-                                        : "proposal-review-entity"
-                                    }
-                                  >
-                                    <code>
-                                      {formatEntityReferenceLabel(entityContext.reference)}
-                                    </code>
-                                    <span>{entityContext.summary}</span>
-                                  </li>
-                                ))}
-                              </ul>
-                            )}
-                          </li>
-                        ))}
-                      </ul>
-                    )}
-                  </section>
-                  {pluginPanelsBySlot.proposalReview.length === 0 ? (
-                    <p>No proposal-review plugin panels.</p>
-                  ) : (
-                    <ul className="proposal-plugin-list">
-                      {pluginPanelsBySlot.proposalReview.map((panel) => (
-                        <li key={`${panel.namespace}:${panel.panelId}`}>
-                          <strong>{panel.title}</strong>
-                          <span>
-                            {panel.namespace}/{panel.panelId}
-                          </span>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-                </section>
               </main>
             </>
           ) : (

--- a/apps/ui/src/app.test.tsx
+++ b/apps/ui/src/app.test.tsx
@@ -14,13 +14,5 @@ describe("App", () => {
     expect(html).toContain("Search notes");
     expect(html).toContain("Lexical editor loads in the browser.");
     expect(html).toContain("Unsaved");
-    expect(html).toContain("Plugin Sidebar Panels");
-    expect(html).toContain("No toolbar plugin panels.");
-    expect(html).toContain("Proposal Review Panels");
-    expect(html).toContain("Entity-Aware Context");
-    expect(html).toContain("Select a saved note to inspect proposal context.");
-    expect(html).toContain("No entity-aware proposal context for this note.");
-    expect(html).toContain("Plugin Commands");
-    expect(html).toContain("No plugin commands.");
   });
 });


### PR DESCRIPTION
Summary
- drop the sidebar, toolbar, proposal review panels, command surface, and related logic tied to the hosted plugin endpoints
- trim proposal model plumbing that was only used by those plugin UIs so the editor UI now solely focuses on the core experience
Testing
- Not run (not requested)