### PR TITLE
Make dev ports dynamic to avoid conflicts

### DIFF
--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -1,10 +1,29 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
+const defaultUiHost = "127.0.0.1";
+const defaultUiPort = 5173;
+
+function resolveUiPort(rawPort: string | undefined): number {
+  if (!rawPort) {
+    return defaultUiPort;
+  }
+
+  const parsed = Number.parseInt(rawPort, 10);
+  if (Number.isNaN(parsed) || parsed < 1 || parsed > 65535) {
+    return defaultUiPort;
+  }
+
+  return parsed;
+}
+
+const devHost = process.env.REM_UI_HOST ?? defaultUiHost;
+const devPort = resolveUiPort(process.env.REM_UI_PORT);
+
 export default defineConfig({
   plugins: [react()],
   server: {
-    host: "127.0.0.1",
-    port: 5173,
+    host: devHost,
+    port: devPort,
   },
 });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "packageManager": "bun@1.3.4",
   "workspaces": ["apps/*", "packages/*"],
   "scripts": {
-    "dev": "concurrently -n api,ui -c yellow,cyan \"bun run dev:api\" \"bun run dev:ui\"",
+    "dev": "bun run scripts/dev.ts",
+    "dev:stack": "concurrently -n api,ui -c yellow,cyan \"bun run dev:api\" \"bun run dev:ui\"",
     "dev:api": "bun run --cwd apps/api dev",
     "dev:ui": "bun run --cwd apps/ui dev",
     "build:ui": "bun run --cwd apps/ui build",

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -1,0 +1,161 @@
+#!/usr/bin/env bun
+import { createServer } from "node:net";
+
+const defaultApiHost = "127.0.0.1";
+const defaultUiHost = "127.0.0.1";
+const defaultApiPort = 8787;
+const defaultUiPort = 5173;
+const maxPreferredPortScan = 50;
+const maxEphemeralAttempts = 20;
+
+function parsePreferredPort(
+  rawValue: string | undefined,
+  fallback: number,
+  envName: string,
+): number {
+  if (!rawValue) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(rawValue, 10);
+  if (Number.isNaN(parsed) || parsed < 1 || parsed > 65535) {
+    process.stderr.write(`warning: ignoring invalid ${envName}=${rawValue}; using ${fallback}\n`);
+    return fallback;
+  }
+
+  return parsed;
+}
+
+function canBindPort(host: string, port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = createServer();
+    let finalized = false;
+
+    const finalize = (result: boolean): void => {
+      if (finalized) {
+        return;
+      }
+      finalized = true;
+      resolve(result);
+    };
+
+    server.once("error", () => {
+      finalize(false);
+    });
+
+    server.listen(port, host, () => {
+      server.close(() => {
+        finalize(true);
+      });
+    });
+  });
+}
+
+function claimEphemeralPort(host: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+
+    server.once("error", (error) => {
+      reject(error);
+    });
+
+    server.listen(0, host, () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("Unable to determine ephemeral port")));
+        return;
+      }
+
+      const { port } = address;
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(port);
+      });
+    });
+  });
+}
+
+async function findOpenPort(
+  host: string,
+  preferredPort: number,
+  excludedPorts: Set<number> = new Set(),
+): Promise<number> {
+  for (let offset = 0; offset < maxPreferredPortScan; offset += 1) {
+    const candidate = preferredPort + offset;
+    if (candidate > 65535) {
+      break;
+    }
+    if (excludedPorts.has(candidate)) {
+      continue;
+    }
+    if (await canBindPort(host, candidate)) {
+      return candidate;
+    }
+  }
+
+  for (let attempt = 0; attempt < maxEphemeralAttempts; attempt += 1) {
+    const candidate = await claimEphemeralPort(host);
+    if (!excludedPorts.has(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error(`Unable to find open port on host ${host}`);
+}
+
+async function main(): Promise<void> {
+  const apiHost = process.env.REM_API_HOST?.trim() || defaultApiHost;
+  const uiHost = process.env.REM_UI_HOST?.trim() || defaultUiHost;
+  const preferredApiPort = parsePreferredPort(
+    process.env.REM_API_PORT,
+    defaultApiPort,
+    "REM_API_PORT",
+  );
+  const preferredUiPort = parsePreferredPort(process.env.REM_UI_PORT, defaultUiPort, "REM_UI_PORT");
+
+  const apiPort = await findOpenPort(apiHost, preferredApiPort);
+  const uiPort = await findOpenPort(uiHost, preferredUiPort, new Set([apiPort]));
+  const apiBaseUrl = `http://${apiHost}:${apiPort}`;
+  const uiBaseUrl = `http://${uiHost}:${uiPort}`;
+
+  process.stdout.write(`dev ports selected api=${apiPort} ui=${uiPort}\n`);
+  process.stdout.write(`ui: ${uiBaseUrl}\n`);
+  process.stdout.write(`api: ${apiBaseUrl}\n`);
+
+  const child = Bun.spawn(["bun", "run", "dev:stack"], {
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+    env: {
+      ...process.env,
+      REM_API_HOST: apiHost,
+      REM_API_PORT: String(apiPort),
+      REM_UI_HOST: uiHost,
+      REM_UI_PORT: String(uiPort),
+      VITE_REM_API_BASE_URL: apiBaseUrl,
+    },
+  });
+
+  const handleInterrupt = () => {
+    child.kill();
+  };
+
+  process.on("SIGINT", handleInterrupt);
+  process.on("SIGTERM", handleInterrupt);
+
+  const exitCode = await child.exited;
+
+  process.off("SIGINT", handleInterrupt);
+  process.off("SIGTERM", handleInterrupt);
+
+  process.exit(exitCode);
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
Summary
- add a `scripts/dev.ts` launcher that dynamically picks open API/UI ports, injects them into env vars, and reuses the existing stack script
- remove `concurrently` from `dev` in favor of the launcher while keeping the old behaviour behind `dev:stack`
- teach the UI Vite config to respect `REM_UI_HOST`/`REM_UI_PORT` so the dynamic ports are honored

Testing
- Not run (not requested)