### PR TITLE
Update macOS installer to set rem alias

### DIFF
--- a/scripts/install-macos.sh
+++ b/scripts/install-macos.sh
@@ -6,6 +6,8 @@ PACKAGE_DIR="$SCRIPT_DIR"
 
 INSTALL_DIR="${REM_INSTALL_DIR:-/opt/rem}"
 BIN_DIR="${REM_BIN_DIR:-/usr/local/bin}"
+ALIAS_BLOCK_BEGIN="# >>> rem alias (managed by rem installer) >>>"
+ALIAS_BLOCK_END="# <<< rem alias (managed by rem installer) <<<"
 
 usage() {
   cat <<'EOF'
@@ -24,6 +26,47 @@ Options:
                         bin dir:     $HOME/.local/bin
   -h, --help            Show this help message.
 EOF
+}
+
+resolve_shell_home() {
+  if [[ -n "${SUDO_USER:-}" ]]; then
+    local sudo_home
+    sudo_home="$(dscl . -read "/Users/$SUDO_USER" NFSHomeDirectory 2>/dev/null | awk '{print $2}')"
+    if [[ -n "$sudo_home" ]]; then
+      printf '%s\n' "$sudo_home"
+      return
+    fi
+  fi
+  printf '%s\n' "$HOME"
+}
+
+configure_zsh_alias() {
+  local launcher_path="$1"
+  local shell_home
+  local zshrc_path
+  local tmp_file
+
+  shell_home="$(resolve_shell_home)"
+  zshrc_path="$shell_home/.zshrc"
+  mkdir -p "$shell_home"
+  touch "$zshrc_path"
+
+  tmp_file="$(mktemp)"
+  sed "/^$ALIAS_BLOCK_BEGIN$/,/^$ALIAS_BLOCK_END$/d" "$zshrc_path" >"$tmp_file"
+  cat >>"$tmp_file" <<EOF
+
+$ALIAS_BLOCK_BEGIN
+alias rem='$launcher_path'
+$ALIAS_BLOCK_END
+EOF
+  cat "$tmp_file" >"$zshrc_path"
+  rm -f "$tmp_file"
+
+  if [[ -n "${SUDO_USER:-}" ]]; then
+    chown "$SUDO_USER" "$zshrc_path" 2>/dev/null || true
+  fi
+
+  printf 'Updated zsh alias in %s\n' "$zshrc_path"
 }
 
 while [[ $# -gt 0 ]]; do
@@ -93,6 +136,8 @@ if command -v xattr >/dev/null 2>&1; then
   xattr -dr com.apple.quarantine "$INSTALL_DIR" 2>/dev/null || true
   xattr -d com.apple.quarantine "$LAUNCHER_PATH" 2>/dev/null || true
 fi
+
+configure_zsh_alias "$LAUNCHER_PATH"
 
 printf 'Installed rem:\n- install dir: %s\n- launcher: %s\n\n' "$INSTALL_DIR" "$LAUNCHER_PATH"
 printf 'Run: %s app\n' "$LAUNCHER_PATH"


### PR DESCRIPTION
Summary
- add alias management hooks to the macOS install script so it cleans and rewrites the rem block in the user’s `.zshrc`
- discover the running user’s home directory (including when sudo is used) and persist the alias with ownership

Testing
- Not run (not requested)