### PR TITLE
Update sidebar toggle shortcut to cmd+B

### DIFF
--- a/apps/ui/src/keyboard-shortcuts.test.ts
+++ b/apps/ui/src/keyboard-shortcuts.test.ts
@@ -8,21 +8,21 @@ describe("keyboard shortcut helpers", () => {
       isSidebarToggleShortcut({
         metaKey: true,
         ctrlKey: false,
-        key: "\\",
+        key: "b",
       }),
     ).toBeTrue();
     expect(
       isSidebarToggleShortcut({
         metaKey: false,
         ctrlKey: true,
-        key: "\\",
+        key: "B",
       }),
     ).toBeTrue();
     expect(
       isSidebarToggleShortcut({
         metaKey: false,
         ctrlKey: false,
-        key: "\\",
+        key: "b",
       }),
     ).toBeFalse();
   });

--- a/apps/ui/src/keyboard-shortcuts.ts
+++ b/apps/ui/src/keyboard-shortcuts.ts
@@ -9,7 +9,7 @@ function hasMetaOrCtrl(event: ShortcutEvent): boolean {
 }
 
 export function isSidebarToggleShortcut(event: ShortcutEvent): boolean {
-  return hasMetaOrCtrl(event) && event.key === "\\";
+  return hasMetaOrCtrl(event) && event.key.toLowerCase() === "b";
 }
 
 export function isCommandPaletteShortcut(event: ShortcutEvent): boolean {


### PR DESCRIPTION
Summary
- switch the sidebar toggle shortcut detection to listen for the “b” key when combined with meta or ctrl
- update keyboard shortcut tests to reflect the new shortcut and case insensitivity

Testing
- Not run (not requested)