### PR TITLE
Add command palette note creation and navigation enhancements

### DIFF
--- a/apps/ui/src/command-palette.test.ts
+++ b/apps/ui/src/command-palette.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
-import { matchesCommandQuery } from "./command-palette";
+import {
+  getNextCommandIndex,
+  getPreviousCommandIndex,
+  isNextCommandShortcut,
+  isPreviousCommandShortcut,
+  matchesCommandQuery,
+} from "./command-palette";
 
 describe("command palette query matching", () => {
   test("treats empty query as visible", () => {
@@ -15,5 +21,71 @@ describe("command palette query matching", () => {
 
   test("returns false when aliases do not match", () => {
     expect(matchesCommandQuery("deploy", ["today", "add note"])).toBe(false);
+  });
+
+  test("detects next and previous navigation shortcuts", () => {
+    expect(
+      isNextCommandShortcut({
+        key: "ArrowDown",
+        ctrlKey: false,
+        altKey: false,
+        metaKey: false,
+        shiftKey: false,
+      }),
+    ).toBe(true);
+    expect(
+      isNextCommandShortcut({
+        key: "n",
+        ctrlKey: true,
+        altKey: false,
+        metaKey: false,
+        shiftKey: false,
+      }),
+    ).toBe(true);
+    expect(
+      isPreviousCommandShortcut({
+        key: "ArrowUp",
+        ctrlKey: false,
+        altKey: false,
+        metaKey: false,
+        shiftKey: false,
+      }),
+    ).toBe(true);
+    expect(
+      isPreviousCommandShortcut({
+        key: "p",
+        ctrlKey: true,
+        altKey: false,
+        metaKey: false,
+        shiftKey: false,
+      }),
+    ).toBe(true);
+    expect(
+      isNextCommandShortcut({
+        key: "n",
+        ctrlKey: false,
+        altKey: false,
+        metaKey: false,
+        shiftKey: false,
+      }),
+    ).toBe(false);
+    expect(
+      isPreviousCommandShortcut({
+        key: "p",
+        ctrlKey: false,
+        altKey: false,
+        metaKey: false,
+        shiftKey: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("wraps command index navigation", () => {
+    expect(getNextCommandIndex(0, 2)).toBe(1);
+    expect(getNextCommandIndex(1, 2)).toBe(0);
+    expect(getPreviousCommandIndex(0, 2)).toBe(1);
+    expect(getPreviousCommandIndex(1, 2)).toBe(0);
+    expect(getNextCommandIndex(0, 0)).toBe(0);
+    expect(getPreviousCommandIndex(0, 0)).toBe(0);
   });
 });

--- a/apps/ui/src/command-palette.ts
+++ b/apps/ui/src/command-palette.ts
@@ -6,3 +6,67 @@ export function matchesCommandQuery(query: string, aliases: readonly string[]): 
 
   return aliases.some((alias) => alias.toLowerCase().includes(normalizedQuery));
 }
+
+type CommandPaletteNavigationEvent = {
+  key: string;
+  ctrlKey: boolean;
+  altKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+};
+
+export function isNextCommandShortcut(event: CommandPaletteNavigationEvent): boolean {
+  if (
+    event.key === "ArrowDown" &&
+    !event.ctrlKey &&
+    !event.altKey &&
+    !event.metaKey &&
+    !event.shiftKey
+  ) {
+    return true;
+  }
+
+  return (
+    event.ctrlKey &&
+    !event.altKey &&
+    !event.metaKey &&
+    !event.shiftKey &&
+    event.key.toLowerCase() === "n"
+  );
+}
+
+export function isPreviousCommandShortcut(event: CommandPaletteNavigationEvent): boolean {
+  if (
+    event.key === "ArrowUp" &&
+    !event.ctrlKey &&
+    !event.altKey &&
+    !event.metaKey &&
+    !event.shiftKey
+  ) {
+    return true;
+  }
+
+  return (
+    event.ctrlKey &&
+    !event.altKey &&
+    !event.metaKey &&
+    !event.shiftKey &&
+    event.key.toLowerCase() === "p"
+  );
+}
+
+export function getNextCommandIndex(currentIndex: number, commandCount: number): number {
+  if (commandCount <= 0) {
+    return 0;
+  }
+
+  return (currentIndex + 1) % commandCount;
+}
+
+export function getPreviousCommandIndex(currentIndex: number, commandCount: number): number {
+  if (commandCount <= 0) {
+    return 0;
+  }
+
+  return (currentIndex - 1 + commandCount) % commandCount;
+}


### PR DESCRIPTION
Summary
- add note creation command to the palette that POSTs a new note, opens it, refreshes the list, and closes the palette
- refactor the palette to use a command list, track active index, handle keyboard navigation, and scroll the active entry into view
- add helper utilities and unit tests for matching queries, shortcuts, and wraparound navigation logic

Testing
- Not run (not requested)