### PR TITLE
Add wiki link support to editor

### DIFF
--- a/apps/ui/src/WikiLinkPlugin.tsx
+++ b/apps/ui/src/WikiLinkPlugin.tsx
@@ -1,0 +1,566 @@
+import { $createLinkNode } from "@lexical/link";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import {
+  $createTextNode,
+  $getNodeByKey,
+  $getSelection,
+  $isRangeSelection,
+  $isTextNode,
+  COMMAND_PRIORITY_HIGH,
+  KEY_ARROW_DOWN_COMMAND,
+  KEY_ARROW_UP_COMMAND,
+  KEY_ENTER_COMMAND,
+  KEY_ESCAPE_COMMAND,
+  KEY_TAB_COMMAND,
+  type NodeKey,
+  type TextNode,
+} from "lexical";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { buildDailyTitleDateAliases } from "./daily-note-search";
+import {
+  type WikiLinkSearchNote,
+  buildWikiNoteHref,
+  extractCompletedWikiLinkMatch,
+  extractWikiTypeaheadMatch,
+  normalizeWikiTitle,
+  parseWikiNoteIdFromHref,
+  rankWikiLinkNotes,
+} from "./wiki-links";
+
+export interface WikiLinkNoteSummary {
+  id: string;
+  title: string;
+  updatedAt: string;
+}
+
+export interface WikiLinksPluginProps {
+  notes: WikiLinkNoteSummary[];
+  onOpenNote: (noteId: string) => Promise<void> | void;
+  onCreateNote: (title: string) => Promise<WikiLinkNoteSummary | null>;
+}
+
+type WikiLinkOptionMode = "existing" | "create";
+
+type WikiLinkOption = {
+  mode: WikiLinkOptionMode;
+  label: string;
+  noteId: string | null;
+  helper: string;
+  key: string;
+};
+
+type WikiMenuState = {
+  anchorKey: NodeKey;
+  anchorOffset: number;
+  query: string;
+  replaceableString: string;
+  rect: {
+    left: number;
+    top: number;
+    height: number;
+  };
+};
+
+type ReplacementTarget = {
+  anchorKey: NodeKey;
+  anchorOffset: number;
+  replaceableString: string;
+};
+
+function areMenuStatesEqual(left: WikiMenuState | null, right: WikiMenuState | null): boolean {
+  if (left === right) {
+    return true;
+  }
+
+  if (left === null || right === null) {
+    return false;
+  }
+
+  return (
+    left.anchorKey === right.anchorKey &&
+    left.anchorOffset === right.anchorOffset &&
+    left.query === right.query &&
+    left.replaceableString === right.replaceableString &&
+    left.rect.left === right.rect.left &&
+    left.rect.top === right.rect.top &&
+    left.rect.height === right.rect.height
+  );
+}
+
+function WikiLinkTypeaheadPlugin(props: {
+  notes: WikiLinkNoteSummary[];
+  onCreateNote: WikiLinksPluginProps["onCreateNote"];
+}): React.JSX.Element {
+  const [editor] = useLexicalComposerContext();
+  const [menuState, setMenuState] = useState<WikiMenuState | null>(null);
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const menuStateRef = useRef<WikiMenuState | null>(null);
+  const pendingCompletedMatchRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    menuStateRef.current = menuState;
+  }, [menuState]);
+
+  const searchableNotes = useMemo<WikiLinkSearchNote[]>(
+    () =>
+      props.notes.map((note) => ({
+        ...note,
+        aliases: buildDailyTitleDateAliases(note.title),
+      })),
+    [props.notes],
+  );
+
+  const options = useMemo<WikiLinkOption[]>(() => {
+    if (menuState === null) {
+      return [];
+    }
+
+    const ranked: WikiLinkOption[] = rankWikiLinkNotes(searchableNotes, menuState.query, 8).map(
+      (note) => ({
+        mode: "existing",
+        label: note.title,
+        noteId: note.id,
+        helper: `Open #${note.id.slice(0, 8)}`,
+        key: `existing:${note.id}`,
+      }),
+    );
+
+    const normalizedTitle = normalizeWikiTitle(menuState.query);
+    const hasExactMatch =
+      normalizedTitle.length > 0 &&
+      searchableNotes.some(
+        (note) => normalizeWikiTitle(note.title).toLowerCase() === normalizedTitle.toLowerCase(),
+      );
+
+    if (normalizedTitle.length > 0 && !hasExactMatch) {
+      ranked.unshift({
+        mode: "create",
+        label: normalizedTitle,
+        noteId: null,
+        helper: "Create new note",
+        key: `create:${normalizedTitle.toLowerCase()}`,
+      });
+    }
+
+    return ranked.slice(0, 8);
+  }, [menuState, searchableNotes]);
+
+  useEffect(() => {
+    setHighlightedIndex((current) => {
+      if (options.length === 0) {
+        return 0;
+      }
+
+      return Math.min(current, options.length - 1);
+    });
+  }, [options.length]);
+
+  const closeMenu = useCallback((): void => {
+    setMenuState(null);
+    setHighlightedIndex(0);
+  }, []);
+
+  const insertWikiLink = useCallback(
+    (target: ReplacementTarget, note: WikiLinkNoteSummary): void => {
+      editor.update(() => {
+        const node = $getNodeByKey(target.anchorKey);
+        if (!$isTextNode(node) || !node.isSimpleText()) {
+          return;
+        }
+
+        const textContent = node.getTextContent();
+        const boundedAnchorOffset = Math.min(target.anchorOffset, textContent.length);
+        const startOffset = boundedAnchorOffset - target.replaceableString.length;
+        if (startOffset < 0) {
+          return;
+        }
+
+        if (textContent.slice(startOffset, boundedAnchorOffset) !== target.replaceableString) {
+          return;
+        }
+
+        let matchedNode: TextNode | null = null;
+        if (startOffset === 0) {
+          [matchedNode] = node.splitText(boundedAnchorOffset);
+        } else {
+          [, matchedNode] = node.splitText(startOffset, boundedAnchorOffset);
+        }
+
+        if (!matchedNode) {
+          return;
+        }
+
+        const linkNode = $createLinkNode(buildWikiNoteHref(note.id));
+        linkNode.append($createTextNode(note.title));
+        matchedNode.replace(linkNode);
+        linkNode.selectEnd();
+      });
+    },
+    [editor],
+  );
+
+  const resolveNoteByTitle = useCallback(
+    async (rawTitle: string): Promise<WikiLinkNoteSummary | null> => {
+      const normalizedTitle = normalizeWikiTitle(rawTitle);
+      if (!normalizedTitle) {
+        return null;
+      }
+
+      const existingNote = props.notes.find(
+        (note) => normalizeWikiTitle(note.title).toLowerCase() === normalizedTitle.toLowerCase(),
+      );
+      if (existingNote) {
+        return existingNote;
+      }
+
+      return props.onCreateNote(normalizedTitle);
+    },
+    [props.notes, props.onCreateNote],
+  );
+
+  const applyOption = useCallback(
+    (option: WikiLinkOption): void => {
+      const activeMenuState = menuStateRef.current;
+      if (!activeMenuState) {
+        return;
+      }
+
+      closeMenu();
+
+      const replacementTarget: ReplacementTarget = {
+        anchorKey: activeMenuState.anchorKey,
+        anchorOffset: activeMenuState.anchorOffset,
+        replaceableString: activeMenuState.replaceableString,
+      };
+
+      if (option.mode === "existing" && option.noteId) {
+        const selectedNote = props.notes.find((note) => note.id === option.noteId);
+        if (selectedNote) {
+          insertWikiLink(replacementTarget, selectedNote);
+        }
+        return;
+      }
+
+      void resolveNoteByTitle(option.label).then((note) => {
+        if (!note) {
+          return;
+        }
+        insertWikiLink(replacementTarget, note);
+      });
+    },
+    [closeMenu, insertWikiLink, props.notes, resolveNoteByTitle],
+  );
+
+  const confirmHighlightedOption = useCallback((): boolean => {
+    if (!menuStateRef.current || options.length === 0) {
+      return false;
+    }
+
+    const optionIndex = Math.max(0, Math.min(highlightedIndex, options.length - 1));
+    const option = options[optionIndex];
+    if (!option) {
+      return false;
+    }
+
+    applyOption(option);
+    return true;
+  }, [applyOption, highlightedIndex, options]);
+
+  useEffect(() => {
+    return editor.registerUpdateListener(({ editorState }) => {
+      editorState.read(() => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection) || !selection.isCollapsed()) {
+          setMenuState((current) => (current === null ? current : null));
+          return;
+        }
+
+        const anchor = selection.anchor;
+        const anchorNode = anchor.getNode();
+        if (!$isTextNode(anchorNode) || !anchorNode.isSimpleText()) {
+          setMenuState((current) => (current === null ? current : null));
+          return;
+        }
+
+        const textUpToCaret = anchorNode.getTextContent().slice(0, anchor.offset);
+        const completedMatch = extractCompletedWikiLinkMatch(textUpToCaret);
+        if (completedMatch) {
+          const signature = `${anchorNode.getKey()}:${anchor.offset}:${completedMatch.replaceableString}`;
+          if (pendingCompletedMatchRef.current === signature) {
+            return;
+          }
+
+          pendingCompletedMatchRef.current = signature;
+          setMenuState((current) => (current === null ? current : null));
+
+          const replacementTarget: ReplacementTarget = {
+            anchorKey: anchorNode.getKey(),
+            anchorOffset: anchor.offset,
+            replaceableString: completedMatch.replaceableString,
+          };
+
+          void resolveNoteByTitle(completedMatch.title)
+            .then((note) => {
+              if (!note) {
+                return;
+              }
+              insertWikiLink(replacementTarget, note);
+            })
+            .finally(() => {
+              if (pendingCompletedMatchRef.current === signature) {
+                pendingCompletedMatchRef.current = null;
+              }
+            });
+
+          return;
+        }
+
+        const typeaheadMatch = extractWikiTypeaheadMatch(textUpToCaret);
+        if (!typeaheadMatch) {
+          setMenuState((current) => (current === null ? current : null));
+          return;
+        }
+
+        if (typeof window === "undefined") {
+          setMenuState((current) => (current === null ? current : null));
+          return;
+        }
+
+        const domSelection = window.getSelection();
+        if (!domSelection || domSelection.rangeCount === 0 || !domSelection.isCollapsed) {
+          setMenuState((current) => (current === null ? current : null));
+          return;
+        }
+
+        const range = domSelection.getRangeAt(0).cloneRange();
+        range.collapse(true);
+        const caretRect = range.getBoundingClientRect();
+
+        const nextMenuState: WikiMenuState = {
+          anchorKey: anchorNode.getKey(),
+          anchorOffset: anchor.offset,
+          query: typeaheadMatch.matchingString,
+          replaceableString: typeaheadMatch.replaceableString,
+          rect: {
+            left: caretRect.left,
+            top: caretRect.top,
+            height: caretRect.height || 18,
+          },
+        };
+
+        setMenuState((current) => {
+          if (areMenuStatesEqual(current, nextMenuState)) {
+            return current;
+          }
+
+          if (current?.query !== nextMenuState.query) {
+            setHighlightedIndex(0);
+          }
+
+          return nextMenuState;
+        });
+      });
+    });
+  }, [editor, insertWikiLink, resolveNoteByTitle]);
+
+  const isMenuOpen = menuState !== null && options.length > 0;
+
+  useEffect(() => {
+    return editor.registerCommand(
+      KEY_ARROW_DOWN_COMMAND,
+      (event) => {
+        if (!isMenuOpen) {
+          return false;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+        setHighlightedIndex((current) => {
+          if (options.length === 0) {
+            return 0;
+          }
+          return (current + 1) % options.length;
+        });
+        return true;
+      },
+      COMMAND_PRIORITY_HIGH,
+    );
+  }, [editor, isMenuOpen, options.length]);
+
+  useEffect(() => {
+    return editor.registerCommand(
+      KEY_ARROW_UP_COMMAND,
+      (event) => {
+        if (!isMenuOpen) {
+          return false;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+        setHighlightedIndex((current) => {
+          if (options.length === 0) {
+            return 0;
+          }
+          return (current - 1 + options.length) % options.length;
+        });
+        return true;
+      },
+      COMMAND_PRIORITY_HIGH,
+    );
+  }, [editor, isMenuOpen, options.length]);
+
+  useEffect(() => {
+    return editor.registerCommand(
+      KEY_ENTER_COMMAND,
+      (event) => {
+        if (!isMenuOpen) {
+          return false;
+        }
+
+        if (event !== null) {
+          event.preventDefault();
+          event.stopPropagation();
+        }
+        return confirmHighlightedOption();
+      },
+      COMMAND_PRIORITY_HIGH,
+    );
+  }, [confirmHighlightedOption, editor, isMenuOpen]);
+
+  useEffect(() => {
+    return editor.registerCommand(
+      KEY_TAB_COMMAND,
+      (event) => {
+        if (!isMenuOpen) {
+          return false;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+        return confirmHighlightedOption();
+      },
+      COMMAND_PRIORITY_HIGH,
+    );
+  }, [confirmHighlightedOption, editor, isMenuOpen]);
+
+  useEffect(() => {
+    return editor.registerCommand(
+      KEY_ESCAPE_COMMAND,
+      (event) => {
+        if (!isMenuOpen) {
+          return false;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+        closeMenu();
+        return true;
+      },
+      COMMAND_PRIORITY_HIGH,
+    );
+  }, [closeMenu, editor, isMenuOpen]);
+
+  const menuPosition = useMemo(() => {
+    if (menuState === null || typeof window === "undefined") {
+      return null;
+    }
+
+    const margin = 10;
+    const menuWidth = 340;
+    const nextLeft = Math.max(
+      margin,
+      Math.min(menuState.rect.left, Math.max(margin, window.innerWidth - menuWidth - margin)),
+    );
+    const nextTop = Math.max(
+      margin,
+      Math.min(menuState.rect.top + menuState.rect.height + 8, window.innerHeight - 220),
+    );
+
+    return {
+      left: `${nextLeft}px`,
+      top: `${nextTop}px`,
+    };
+  }, [menuState]);
+
+  if (!isMenuOpen || menuPosition === null || typeof document === "undefined") {
+    return <></>;
+  }
+
+  return createPortal(
+    <div className="wiki-link-menu wiki-link-menu-floating" style={menuPosition}>
+      <ul>
+        {options.map((option, index) => (
+          <li key={option.key}>
+            <button
+              type="button"
+              className={`wiki-link-menu-item ${highlightedIndex === index ? "wiki-link-menu-item-active" : ""}`}
+              onMouseDown={(event) => {
+                event.preventDefault();
+              }}
+              onMouseEnter={() => {
+                setHighlightedIndex(index);
+              }}
+              onClick={() => {
+                setHighlightedIndex(index);
+                applyOption(option);
+              }}
+            >
+              <span className="wiki-link-menu-main">{option.label}</span>
+              <span className="wiki-link-menu-meta">{option.helper}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>,
+    document.body,
+  );
+}
+
+function WikiLinkClickPlugin(props: {
+  onOpenNote: WikiLinksPluginProps["onOpenNote"];
+}): null {
+  const [editor] = useLexicalComposerContext();
+
+  const handleClick = useCallback(
+    (event: MouseEvent): void => {
+      if (!(event.target instanceof HTMLElement)) {
+        return;
+      }
+
+      const anchor = event.target.closest("a");
+      if (!(anchor instanceof HTMLAnchorElement)) {
+        return;
+      }
+
+      const noteId = parseWikiNoteIdFromHref(anchor.getAttribute("href") ?? anchor.href);
+      if (!noteId) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      void props.onOpenNote(noteId);
+    },
+    [props.onOpenNote],
+  );
+
+  useEffect(() => {
+    return editor.registerRootListener((rootElement, prevRootElement) => {
+      prevRootElement?.removeEventListener("click", handleClick);
+      rootElement?.addEventListener("click", handleClick);
+    });
+  }, [editor, handleClick]);
+
+  return null;
+}
+
+export function WikiLinksPlugin(props: WikiLinksPluginProps): React.JSX.Element {
+  return (
+    <>
+      <WikiLinkTypeaheadPlugin notes={props.notes} onCreateNote={props.onCreateNote} />
+      <WikiLinkClickPlugin onOpenNote={props.onOpenNote} />
+    </>
+  );
+}

--- a/apps/ui/src/styles.css
+++ b/apps/ui/src/styles.css
@@ -833,6 +833,17 @@ body {
   margin-bottom: 0;
 }
 
+.lexical-editor a[href^="#/note/"] {
+  color: color-mix(in srgb, var(--text) 82%, var(--status-success));
+  text-decoration-color: color-mix(in srgb, var(--text) 36%, transparent);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.14em;
+}
+
+.lexical-editor a[href^="#/note/"]:hover {
+  color: var(--text);
+}
+
 .lexical-text-strikethrough {
   text-decoration: line-through;
 }
@@ -851,6 +862,62 @@ body {
   left: 0;
   color: #6e7281;
   pointer-events: none;
+}
+
+.wiki-link-menu {
+  width: min(22rem, calc(100vw - 3rem));
+  border: 1px solid color-mix(in srgb, var(--text) 16%, transparent);
+  border-radius: 0.7rem;
+  background: color-mix(in srgb, var(--surface) 90%, var(--panel));
+  box-shadow: 0 0.9rem 2.2rem color-mix(in srgb, #000 36%, transparent);
+  overflow: hidden;
+  z-index: 20;
+}
+
+.wiki-link-menu-floating {
+  position: fixed;
+  z-index: 40;
+}
+
+.wiki-link-menu ul {
+  list-style: none;
+  margin: 0;
+  padding: 0.25rem;
+  display: grid;
+  gap: 0.18rem;
+}
+
+.wiki-link-menu-item {
+  width: 100%;
+  border: 0;
+  border-radius: 0.45rem;
+  background: transparent;
+  color: var(--text);
+  display: grid;
+  gap: 0.08rem;
+  text-align: left;
+  font: inherit;
+  padding: 0.38rem 0.46rem;
+  cursor: pointer;
+}
+
+.wiki-link-menu-item:hover,
+.wiki-link-menu-item:focus-visible,
+.wiki-link-menu-item-active {
+  background: color-mix(in srgb, var(--text) 11%, transparent);
+  outline: none;
+}
+
+.wiki-link-menu-main {
+  font-size: 0.86rem;
+  line-height: 1.3;
+}
+
+.wiki-link-menu-meta {
+  font-size: 0.69rem;
+  color: var(--muted);
+  font-family: "IBM Plex Mono", "SF Mono", monospace;
+  letter-spacing: 0.02em;
 }
 
 .settings-fullscreen-page {

--- a/apps/ui/src/wiki-links.test.ts
+++ b/apps/ui/src/wiki-links.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildWikiNoteHref,
+  extractCompletedWikiLinkMatch,
+  extractWikiTypeaheadMatch,
+  parseWikiNoteIdFromHref,
+  rankWikiLinkNotes,
+} from "./wiki-links";
+
+describe("wiki link helpers", () => {
+  test("builds and parses wiki note hrefs", () => {
+    const href = buildWikiNoteHref("note alpha/42");
+
+    expect(href).toBe("#/note/note%20alpha%2F42");
+    expect(parseWikiNoteIdFromHref(href)).toBe("note alpha/42");
+    expect(parseWikiNoteIdFromHref("http://localhost:5173/#/note/note%20alpha%2F42")).toBe(
+      "note alpha/42",
+    );
+  });
+
+  test("extracts typeahead match for an unfinished wiki link", () => {
+    expect(extractWikiTypeaheadMatch("Ship [[Daily standup")).toEqual({
+      leadOffset: 5,
+      matchingString: "Daily standup",
+      replaceableString: "[[Daily standup",
+    });
+  });
+
+  test("does not match completed wiki link syntax", () => {
+    expect(extractWikiTypeaheadMatch("Ship [[Daily standup]]")).toBeNull();
+  });
+
+  test("extracts a completed wiki link match", () => {
+    expect(extractCompletedWikiLinkMatch("Ship [[Daily standup]]")).toEqual({
+      leadOffset: 5,
+      title: "Daily standup",
+      replaceableString: "[[Daily standup]]",
+    });
+  });
+
+  test("ignores invalid completed wiki link syntax", () => {
+    expect(extractCompletedWikiLinkMatch("Ship [[ ]]")).toBeNull();
+    expect(extractCompletedWikiLinkMatch("Ship [[Nested [note]]")).toBeNull();
+    expect(extractCompletedWikiLinkMatch("Ship [[Daily standup]] later")).toBeNull();
+  });
+
+  test("ranks exact and fuzzy note matches", () => {
+    const notes = [
+      {
+        id: "note-z",
+        title: "Roadmap",
+        updatedAt: "2025-02-01T00:00:00.000Z",
+      },
+      {
+        id: "note-a",
+        title: "Daily Standup",
+        updatedAt: "2025-02-03T00:00:00.000Z",
+      },
+      {
+        id: "note-b",
+        title: "Deployment Plan",
+        updatedAt: "2025-02-02T00:00:00.000Z",
+      },
+    ];
+
+    const exact = rankWikiLinkNotes(notes, "daily standup");
+    expect(exact[0]?.id).toBe("note-a");
+
+    const fuzzy = rankWikiLinkNotes(notes, "dplmnt pln");
+    expect(fuzzy[0]?.id).toBe("note-b");
+  });
+});

--- a/apps/ui/src/wiki-links.ts
+++ b/apps/ui/src/wiki-links.ts
@@ -1,0 +1,236 @@
+export interface WikiLinkSearchNote {
+  id: string;
+  title: string;
+  updatedAt: string;
+  aliases?: string[];
+}
+
+export interface WikiTypeaheadMatch {
+  leadOffset: number;
+  matchingString: string;
+  replaceableString: string;
+}
+
+export interface CompletedWikiLinkMatch {
+  leadOffset: number;
+  title: string;
+  replaceableString: string;
+}
+
+const WIKI_TRIGGER = "[[";
+const WIKI_NOTE_HASH_PREFIX = "#/note/";
+const MAX_WIKI_QUERY_LENGTH = 160;
+
+export function buildWikiNoteHref(noteId: string): string {
+  return `${WIKI_NOTE_HASH_PREFIX}${encodeURIComponent(noteId)}`;
+}
+
+function extractHrefHash(rawHref: string): string {
+  if (rawHref.startsWith("#")) {
+    return rawHref;
+  }
+
+  try {
+    return new URL(rawHref, "http://localhost").hash;
+  } catch {
+    const hashStart = rawHref.indexOf("#");
+    return hashStart === -1 ? "" : rawHref.slice(hashStart);
+  }
+}
+
+export function parseWikiNoteIdFromHref(rawHref: string): string | null {
+  const hash = extractHrefHash(rawHref);
+  if (!hash.startsWith(WIKI_NOTE_HASH_PREFIX)) {
+    return null;
+  }
+
+  const encodedNoteId = hash.slice(WIKI_NOTE_HASH_PREFIX.length);
+  if (encodedNoteId.length === 0) {
+    return null;
+  }
+
+  try {
+    return decodeURIComponent(encodedNoteId);
+  } catch {
+    return encodedNoteId;
+  }
+}
+
+export function normalizeWikiTitle(rawTitle: string): string {
+  return rawTitle.replace(/\s+/g, " ").trim();
+}
+
+export function extractWikiTypeaheadMatch(text: string): WikiTypeaheadMatch | null {
+  const triggerOffset = text.lastIndexOf(WIKI_TRIGGER);
+  if (triggerOffset === -1) {
+    return null;
+  }
+
+  const matchingString = text.slice(triggerOffset + WIKI_TRIGGER.length);
+  if (
+    matchingString.length > MAX_WIKI_QUERY_LENGTH ||
+    matchingString.includes("]") ||
+    matchingString.includes("\n") ||
+    matchingString.includes("\r")
+  ) {
+    return null;
+  }
+
+  return {
+    leadOffset: triggerOffset,
+    matchingString,
+    replaceableString: text.slice(triggerOffset),
+  };
+}
+
+export function extractCompletedWikiLinkMatch(text: string): CompletedWikiLinkMatch | null {
+  const closingOffset = text.lastIndexOf("]]");
+  if (closingOffset === -1 || closingOffset !== text.length - 2) {
+    return null;
+  }
+
+  const triggerOffset = text.lastIndexOf(WIKI_TRIGGER, closingOffset - 1);
+  if (triggerOffset === -1) {
+    return null;
+  }
+
+  const rawTitle = text.slice(triggerOffset + WIKI_TRIGGER.length, closingOffset);
+  if (
+    rawTitle.length > MAX_WIKI_QUERY_LENGTH ||
+    rawTitle.includes("[") ||
+    rawTitle.includes("]") ||
+    rawTitle.includes("\n") ||
+    rawTitle.includes("\r")
+  ) {
+    return null;
+  }
+
+  const title = normalizeWikiTitle(rawTitle);
+  if (title.length === 0) {
+    return null;
+  }
+
+  return {
+    leadOffset: triggerOffset,
+    title,
+    replaceableString: text.slice(triggerOffset, closingOffset + 2),
+  };
+}
+
+function normalizeSearchToken(value: string): string {
+  return normalizeWikiTitle(value).toLowerCase();
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function getSubsequenceGapPenalty(query: string, candidate: string): number | null {
+  let queryIndex = 0;
+  let previousMatchIndex = -1;
+  let gapPenalty = 0;
+
+  for (let index = 0; index < candidate.length && queryIndex < query.length; index += 1) {
+    if (candidate[index] !== query[queryIndex]) {
+      continue;
+    }
+
+    if (previousMatchIndex >= 0) {
+      gapPenalty += Math.max(0, index - previousMatchIndex - 1);
+    }
+    previousMatchIndex = index;
+    queryIndex += 1;
+  }
+
+  if (queryIndex !== query.length) {
+    return null;
+  }
+
+  return gapPenalty;
+}
+
+function scoreCandidate(query: string, candidate: string): number {
+  if (!query || !candidate) {
+    return -1;
+  }
+
+  if (candidate === query) {
+    return 1000;
+  }
+
+  if (candidate.startsWith(query)) {
+    return 850 - Math.min(200, candidate.length - query.length);
+  }
+
+  const boundaryMatchIndex = candidate.search(new RegExp(`\\b${escapeRegExp(query)}`));
+  if (boundaryMatchIndex >= 0) {
+    return 730 - Math.min(240, boundaryMatchIndex * 6);
+  }
+
+  const includesIndex = candidate.indexOf(query);
+  if (includesIndex >= 0) {
+    return 620 - Math.min(220, includesIndex * 4);
+  }
+
+  const subsequenceGapPenalty = getSubsequenceGapPenalty(query, candidate);
+  if (subsequenceGapPenalty !== null) {
+    return 420 - Math.min(320, subsequenceGapPenalty * 8);
+  }
+
+  return -1;
+}
+
+export function rankWikiLinkNotes(
+  notes: readonly WikiLinkSearchNote[],
+  query: string,
+  limit = 8,
+): WikiLinkSearchNote[] {
+  const normalizedQuery = normalizeSearchToken(query);
+
+  if (normalizedQuery.length === 0) {
+    return [...notes]
+      .sort(
+        (left, right) =>
+          right.updatedAt.localeCompare(left.updatedAt) || left.title.localeCompare(right.title),
+      )
+      .slice(0, limit);
+  }
+
+  const scored = notes
+    .map((note) => {
+      const terms = [note.title, note.id, ...(note.aliases ?? [])]
+        .map(normalizeSearchToken)
+        .filter((token, index, tokens) => token.length > 0 && tokens.indexOf(token) === index);
+
+      const score = terms.reduce((bestScore, term, index) => {
+        const candidateScore = scoreCandidate(normalizedQuery, term);
+        if (candidateScore < 0) {
+          return bestScore;
+        }
+
+        const termWeight = index === 0 ? 0 : index === 1 ? -35 : -15;
+        return Math.max(bestScore, candidateScore + termWeight);
+      }, -1);
+
+      return {
+        note,
+        score,
+      };
+    })
+    .filter((entry) => entry.score >= 0);
+
+  scored.sort((left, right) => {
+    if (left.score !== right.score) {
+      return right.score - left.score;
+    }
+
+    const updatedAtOrder = right.note.updatedAt.localeCompare(left.note.updatedAt);
+    if (updatedAtOrder !== 0) {
+      return updatedAtOrder;
+    }
+
+    return left.note.title.localeCompare(right.note.title);
+  });
+
+  return scored.slice(0, limit).map((entry) => entry.note);
+}


### PR DESCRIPTION
Summary
- research existing lexical provider plugins to understand wiki-style link handling
- update UI, plugin wiring, styles, and tests to implement [[note]] creation, linking, and navigation within the editor
- ensure wiki link interactions align with recent ability to create notes in the UI

Testing
- Not run (not requested)