### PR TITLE
Update docs to reflect implemented architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,36 @@ bun run lint
 bun run format
 ```
 
+## Documentation Contract
+
+Documentation must match shipped behavior in code. If docs and code disagree, code wins and docs must be updated in the same session.
+
+### Path rules
+
+- Use repo-relative paths in documentation and handoff notes.
+- Do not use absolute filesystem paths in docs (worktrees differ per session).
+
+### Required doc updates by change type
+
+1. API routes, request/response shapes, CLI commands/options:
+   - `docs/api-cli-reference.md`
+2. Canonical storage layout, schemas, events, lifecycle/data contracts:
+   - `docs/data-contracts.md`
+3. Operator workflows and smoke checks:
+   - `docs/runbook.md`
+4. Architecture/spec intent docs:
+   - `docs/design.md`
+   - `docs/plugin-runtime-spec.md`
+   - Clearly label statements as `implemented` vs `planned`.
+
+### Guardrails
+
+1. Do not document a UI capability unless it is wired in `apps/ui/src/App.tsx` (or mark it as planned).
+2. Keep command examples aligned with actual CLI command names/options.
+3. Update each touched doc's `Last updated` date.
+4. If behavior changed and no docs changed, work is not complete.
+5. Session handoff must list docs updated and any remaining doc debt as beads.
+
 ## CLI Proposal Workflow
 
 ```bash

--- a/docs/extension-playbook.md
+++ b/docs/extension-playbook.md
@@ -153,7 +153,7 @@ Event evolution:
 | Declarative templates (list/apply) | `packages/core/src/index.ts`, `apps/cli/src/index.ts`, `apps/api/src/index.ts` |
 | Plugin-defined entities + links + FTS | `packages/schemas/src/index.ts`, `packages/store-fs/src/index.ts`, `packages/index-sqlite/src/index.ts`, `packages/core/src/index.ts` |
 | Entity migration workflow (CLI/API) | `apps/cli/src/index.ts`, `apps/api/src/index.ts`, `packages/core/src/index.ts` |
-| UI panel slots + commands + entity-aware proposal context | `apps/ui/src/plugin-panels.ts`, `apps/ui/src/plugin-commands.ts`, `apps/ui/src/proposals.ts`, `apps/ui/src/App.tsx` |
+| UI panel/command/proposal helper modules (runtime wiring still pending) | `apps/ui/src/plugin-panels.ts`, `apps/ui/src/plugin-commands.ts`, `apps/ui/src/proposals.ts` |
 | Security hardening (trusted roots, traversal protection, auth parity) | `packages/plugins/src/index.ts`, `apps/api/src/index.ts`, `apps/cli/src/index.ts` |
 
 ## Future session handoff template

--- a/docs/plugin-runtime-rollout-checklist.md
+++ b/docs/plugin-runtime-rollout-checklist.md
@@ -15,7 +15,7 @@ Enable Plugin Runtime v1 surfaces in production with:
 - guarded action runtime in CLI and API hosts
 - templates/scheduler support
 - plugin-defined entities with deterministic migration workflows
-- UI plugin command/panel surfaces and entity-aware proposal context
+- UI editor stability with deferred plugin command/panel runtime integration
 
 ## Exit criteria (must all be true)
 
@@ -51,7 +51,7 @@ Enable Plugin Runtime v1 surfaces in production with:
 - [ ] CLI `plugin run` and API `/plugins/:namespace/actions/:actionId` emit action events
 - [ ] templates list/apply work in CLI and API
 - [ ] scheduler run/status work and ledger updates idempotently
-- [ ] UI renders plugin panels/commands and proposal entity context without breaking editor flow
+- [ ] UI editor remains stable while plugin panel/command runtime surfaces are deferred
 
 ## Gate 3: Entity migration readiness
 
@@ -124,7 +124,7 @@ Expect:
 | scheduler | `plugin scheduler run/status` and `/scheduler*` | idempotent ledger/task event behavior |
 | entities CRUD | `entities save/get/list` and `/entities*` | schema validation + compatibility metadata |
 | entity migration | `entities migrate` and `/entities/migrations/run` | deterministic planning/execution |
-| proposal context UI | open note with proposal refs | entity-aware person/meeting context displayed |
+| proposal context helpers | unit tests for proposal/entity parsing helpers | deterministic extraction behavior |
 | rebuild parity | `rebuild-index` + `status` | canonical/derived counts remain consistent |
 
 ## Known risks and mitigations

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -251,7 +251,7 @@ rem is not “just a notes app” and not “just a vector DB.” It’s a **mem
 **CLI:**
 - `rem search "query" --json`
 - `rem get note <id> --format lexical|text|md --json`
-- `rem propose section --note <id> --section <sid> --content <file|stdin> --json`
+- `rem proposals create --note <id> --section <sid> --text "<content>" --json`
 - `rem proposals list --status open --json`
 - `rem proposals accept <pid> --json`
 - `rem proposals reject <pid> --json`

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -170,9 +170,9 @@ bun run --cwd apps/cli src/index.ts proposals accept <proposal-id> --json
 bun run --cwd apps/cli src/index.ts proposals reject <proposal-id> --json
 ```
 
-UI behavior:
-- proposal review surface renders declarative plugin panels for slot `proposal.review`
-- entity-aware proposal context resolves person/meeting references from proposal + section context
+UI behavior (current implementation):
+- review and approval are currently performed through CLI/API proposal commands
+- the UI currently focuses on note editing, daily-note startup flow, and command palette actions (`Today`, `Add Note`)
 
 ## Core note/search/events lifecycle (CLI)
 
@@ -310,5 +310,5 @@ Manual smoke checks:
 3. Run scheduler and verify `plugin.task_ran` plus ledger updates.
 4. Create/list/get entity and verify compatibility metadata.
 5. Execute entity migration dry-run and one real run.
-6. Open UI proposal review and verify entity-aware context appears for person/meeting references.
+6. Verify proposal review/accept/reject through CLI or API routes.
 7. Rebuild index and verify status counters stay consistent.

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -2,8 +2,8 @@
 
 **Document status:** Draft (v1)
 **Owner:** Erik
-**Last updated:** 2026-02-10
-**Purpose:** Canonical source of truth for stack and structural decisions before implementation.
+**Last updated:** 2026-02-22
+**Purpose:** Canonical source of truth for current stack and structural decisions used by implementation.
 
 ---
 
@@ -33,7 +33,7 @@ This document defines the agreed technical stack and package boundaries for V1.
 - HTTP server: **Hono**
 - HTTP bind default: `127.0.0.1` (local-only)
 - CLI framework: **Commander**
-- API and CLI behavior: both are thin adapters over the same Core service layer
+- API and CLI behavior: both call the same Core service layer and also host plugin runtime execution/policy checks.
 
 ## 2.3 Validation and Schemas
 - Validation library: **Zod** (source of truth)
@@ -100,8 +100,8 @@ These rules define which app/package layers may depend on which others.
 
 ## 5.1 Allowed imports by layer
 - `apps/ui` -> `packages/core`, `packages/shared`, `packages/schemas`, `packages/plugins`, `packages/extractor-lexical`
-- `apps/api` -> `packages/core`, `packages/shared`, `packages/schemas`
-- `apps/cli` -> `packages/core`, `packages/shared`, `packages/schemas`
+- `apps/api` -> `packages/core`, `packages/shared`, `packages/schemas`, `packages/plugins`
+- `apps/cli` -> `packages/core`, `packages/shared`, `packages/schemas`, `packages/plugins`
 - `packages/core` -> `packages/store-fs`, `packages/index-sqlite`, `packages/schemas`, `packages/plugins`, `packages/extractor-lexical`, `packages/shared`
 - `packages/index-sqlite` -> `packages/shared` (and SQL/runtime deps only)
 - `packages/store-fs` -> `packages/shared` (and Node/Bun fs/path deps only)
@@ -120,7 +120,7 @@ These rules define which app/package layers may depend on which others.
 
 ## 5.3 Boundary intent
 - `core` is the orchestrator and only canonical write entrypoint.
-- adapters (`ui`, `api`, `cli`) stay thin and transport-focused.
+- adapters (`ui`, `api`, `cli`) remain boundary layers; API/CLI additionally host plugin runtime invocation and guardrails.
 - lower-level packages (`store-fs`, `index-sqlite`, `extractor-lexical`) remain single-purpose and side-effect scoped.
 
 ## 5.4 Rule change policy


### PR DESCRIPTION
Summary
- Expand `AGENTS.md` with the documentation contract, path rules, required doc owners, and guardrails so future sessions follow consistent practices.
- Sync implementation-facing docs (`docs/design.md`, `docs/extension-playbook.md`, `docs/plugin-runtime-rollout-checklist.md`, `docs/plugin-runtime-spec.md`, `docs/prd.md`, `docs/runbook.md`, `docs/tech-stack.md`) with the shipped architecture, behaviors, and implementation details.
- Confirm the documented CLI/API surfaces and observability notes now match the actual implemented routes, commands, and runtime stack.

Testing
- Not run (not requested)