### PR TITLE
feat(cli): add cross-platform rem update command

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -1,4 +1,4 @@
-name: Release macOS
+name: Release binaries
 
 on:
   workflow_run:
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: release-macos-main
+  group: release-binaries-main
   cancel-in-progress: false
 
 jobs:
@@ -58,7 +58,7 @@ jobs:
           echo "release_name=REM ${TAG}" >> "$GITHUB_OUTPUT"
 
   build:
-    name: Build (${{ matrix.arch }})
+    name: Build (${{ matrix.target }}-${{ matrix.arch }})
     needs: prepare
     if: needs.prepare.outputs.release_needed == 'true'
     strategy:
@@ -67,8 +67,16 @@ jobs:
         include:
           # macOS 13 was retired in Dec 2025; use the current Intel runner label.
           - runner: macos-15-intel
+            target: macos
+            arch: x64
+          - runner: ubuntu-latest
+            target: linux
+            arch: x64
+          - runner: windows-latest
+            target: windows
             arch: x64
           - runner: macos-14
+            target: macos
             arch: arm64
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
@@ -87,15 +95,48 @@ jobs:
         run: bun install
 
       - name: Build macOS package
+        if: matrix.target == 'macos'
         run: ./scripts/package-macos.sh "${{ needs.prepare.outputs.version }}"
+        shell: bash
 
-      - name: Upload package artifact
+      - name: Build Linux package
+        if: matrix.target == 'linux'
+        run: ./scripts/package-linux.sh "${{ needs.prepare.outputs.version }}"
+        shell: bash
+
+      - name: Build Windows package
+        if: matrix.target == 'windows'
+        run: ./scripts/package-windows.ps1 "${{ needs.prepare.outputs.version }}"
+        shell: pwsh
+
+      - name: Upload macOS package artifact
+        if: matrix.target == 'macos'
         uses: actions/upload-artifact@v4
         with:
-          name: rem-macos-${{ matrix.arch }}
+          name: rem-${{ matrix.target }}-${{ matrix.arch }}
           path: |
             dist/macos/*.tar.gz
             dist/macos/*.tar.gz.sha256
+          if-no-files-found: error
+
+      - name: Upload Linux package artifact
+        if: matrix.target == 'linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: rem-${{ matrix.target }}-${{ matrix.arch }}
+          path: |
+            dist/linux/*.tar.gz
+            dist/linux/*.tar.gz.sha256
+          if-no-files-found: error
+
+      - name: Upload Windows package artifact
+        if: matrix.target == 'windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: rem-${{ matrix.target }}-${{ matrix.arch }}
+          path: |
+            dist/windows/*.zip
+            dist/windows/*.zip.sha256
           if-no-files-found: error
 
   publish:
@@ -123,3 +164,5 @@ jobs:
           files: |
             dist/release/*.tar.gz
             dist/release/*.tar.gz.sha256
+            dist/release/*.zip
+            dist/release/*.zip.sha256

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Package contents:
 - `rem-api` (API server binary)
 - `ui-dist/` (built UI assets)
 - `install.sh` (installs rem to `/opt/rem` and creates `/usr/local/bin/rem`)
+- `VERSION` (installed version marker used by `rem update`)
 
 Run full REM from the package directory:
 
@@ -73,6 +74,13 @@ Install without sudo into your home directory:
 
 ```bash
 ./install.sh --local
+```
+
+Upgrade an installed macOS binary in place:
+
+```bash
+rem update --check
+rem update
 ```
 
 ## Release versioning

--- a/README.md
+++ b/README.md
@@ -30,53 +30,42 @@ bun run test
 bun run test:ci
 ```
 
-## macOS distribution (binary)
+## Binary distribution packages
 
-Create a distributable macOS package locally:
+Create platform packages locally:
 
 ```bash
 bun run package:macos
+bun run package:linux
+bun run package:windows
 ```
 
-Package output:
-- `dist/macos/rem-<version>-macos-<arch>.tar.gz`
-- `dist/macos/rem-<version>-macos-<arch>.tar.gz.sha256`
-
-Quick install from a release tarball:
-
-```bash
-tar -xzf rem-<version>-macos-<arch>.tar.gz
-cd rem-<version>-macos-<arch>
-./install.sh
-rem app
-```
+Package outputs:
+- macOS: `dist/macos/rem-<version>-macos-<arch>.tar.gz` (+ `.sha256`)
+- Linux: `dist/linux/rem-<version>-linux-<arch>.tar.gz` (+ `.sha256`)
+- Windows: `dist/windows/rem-<version>-windows-<arch>.zip` (+ `.sha256`)
 
 Package contents:
-- `rem` (CLI + `rem app` launcher)
-- `rem-api` (API server binary)
+- runtime binaries (`rem`, `rem-api`, or `rem.exe`, `rem-api.exe`)
 - `ui-dist/` (built UI assets)
-- `install.sh` (installs rem to `/opt/rem` and creates `/usr/local/bin/rem`)
+- platform installer (`install.sh` on macOS/Linux, `install.ps1` on Windows)
 - `VERSION` (installed version marker used by `rem update`)
 
-Run full REM from the package directory:
+Install from extracted package:
 
 ```bash
-./rem app
-```
-
-Install rem system-wide from the package directory:
-
-```bash
+# macOS/Linux
+tar -xzf rem-<version>-<platform>-<arch>.tar.gz
+cd rem-<version>-<platform>-<arch>
 ./install.sh
+
+# Windows (PowerShell)
+Expand-Archive rem-<version>-windows-<arch>.zip -DestinationPath .
+cd rem-<version>-windows-<arch>
+powershell -NoProfile -ExecutionPolicy Bypass -File .\install.ps1
 ```
 
-Install without sudo into your home directory:
-
-```bash
-./install.sh --local
-```
-
-Upgrade an installed macOS binary in place:
+Upgrade an installed binary in place:
 
 ```bash
 rem update --check

--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -167,6 +167,16 @@ describe("cli e2e contracts", () => {
     }
   });
 
+  test("exposes update command help", () => {
+    const help = runCli(["update", "--help"], process.env);
+    expect(help.exitCode).toBe(0);
+
+    const output = parseTextStdout(help.stdout);
+    expect(output).toContain("Download and install a rem macOS release package in place");
+    expect(output).toContain("--check");
+    expect(output).toContain("--force");
+  });
+
   test("registers v2 plugin manifests and preserves normalized compatibility metadata", async () => {
     const storeRoot = await mkdtemp(path.join(tmpdir(), "rem-cli-plugin-v2-"));
     const manifestPath = path.join(storeRoot, "manifest-v2.json");

--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -172,7 +172,8 @@ describe("cli e2e contracts", () => {
     expect(help.exitCode).toBe(0);
 
     const output = parseTextStdout(help.stdout);
-    expect(output).toContain("Download and install a rem macOS release package in place");
+    expect(output).toContain("Download and install a rem release package in place");
+    expect(output).toContain("Install into user-local defaults for the current");
     expect(output).toContain("--check");
     expect(output).toContain("--force");
   });

--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -178,6 +178,19 @@ describe("cli e2e contracts", () => {
     expect(output).toContain("--force");
   });
 
+  test("emits JSON error for invalid update arch option", () => {
+    const runInvalidArch = runCli(
+      ["update", "--check", "--arch", "invalid", "--json"],
+      process.env,
+    );
+    expect(runInvalidArch.exitCode).toBe(1);
+    const payload = parseJsonStdout(runInvalidArch.stdout) as {
+      error: { code: string; message: string };
+    };
+    expect(payload.error.code).toBe("update_invalid_arch");
+    expect(payload.error.message).toContain("Expected: arm64|x64");
+  });
+
   test("registers v2 plugin manifests and preserves normalized compatibility metadata", async () => {
     const storeRoot = await mkdtemp(path.join(tmpdir(), "rem-cli-plugin-v2-"));
     const manifestPath = path.join(storeRoot, "manifest-v2.json");

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -394,16 +394,16 @@ program
 
 program
   .command("update")
-  .description("Download and install a rem macOS release package in place")
+  .description("Download and install a rem release package in place")
   .option("--repo <owner/repo>", "GitHub repository slug", "ejohane/rem")
   .option(
     "--version <version>",
     "Target release version (MAJOR.MINOR.PATCH). Defaults to latest release.",
   )
-  .option("--arch <arch>", "Target macOS package arch override: arm64|x64")
+  .option("--arch <arch>", "Target package arch override: arm64|x64")
   .option("--install-dir <path>", "Installer install directory override")
   .option("--bin-dir <path>", "Installer launcher directory override")
-  .option("--local", "Install without sudo into $HOME/.local")
+  .option("--local", "Install into user-local defaults for the current platform")
   .option("--check", "Check for updates without installing")
   .option("--force", "Reinstall even when already on the target version")
   .option("--json", "Emit JSON output")
@@ -439,20 +439,20 @@ program
 
         if (result.outcome === "up_to_date") {
           process.stdout.write(
-            `already up to date: version=${result.targetVersion} tag=${result.tag} arch=${result.arch}\n`,
+            `already up to date: platform=${result.platform} version=${result.targetVersion} tag=${result.tag} arch=${result.arch}\n`,
           );
           return;
         }
 
         if (result.checkOnly || result.outcome === "available") {
           process.stdout.write(
-            `update available: current=${result.currentVersion ?? "unknown"} target=${result.targetVersion} tag=${result.tag} arch=${result.arch}\n`,
+            `update available: platform=${result.platform} current=${result.currentVersion ?? "unknown"} target=${result.targetVersion} tag=${result.tag} arch=${result.arch}\n`,
           );
           return;
         }
 
         process.stdout.write(
-          `updated rem to version=${result.targetVersion} tag=${result.tag} arch=${result.arch}\n`,
+          `updated rem: platform=${result.platform} version=${result.targetVersion} tag=${result.tag} arch=${result.arch}\n`,
         );
       } catch (error) {
         if (error instanceof UpdateCommandError) {

--- a/apps/cli/src/update.test.ts
+++ b/apps/cli/src/update.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  UpdateCommandError,
+  extractSha256Digest,
+  extractVersionFromTag,
+  normalizeSemverInput,
+  resolveCurrentVersionHint,
+  resolveMacosArchiveArch,
+  resolveReleaseAssets,
+} from "./update";
+
+describe("update helpers", () => {
+  test("normalizes semantic versions with or without leading v", () => {
+    expect(normalizeSemverInput("1.2.3", "version")).toBe("1.2.3");
+    expect(normalizeSemverInput("v1.2.3", "version")).toBe("1.2.3");
+  });
+
+  test("rejects invalid semantic versions", () => {
+    let thrown: unknown;
+    try {
+      normalizeSemverInput("1.2", "version");
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(UpdateCommandError);
+    expect((thrown as UpdateCommandError).code).toBe("update_invalid_version");
+  });
+
+  test("extracts semantic version from release tags", () => {
+    expect(extractVersionFromTag("v0.1.0")).toBe("0.1.0");
+  });
+
+  test("maps process architecture to macOS archive architecture", () => {
+    expect(resolveMacosArchiveArch("arm64")).toBe("arm64");
+    expect(resolveMacosArchiveArch("x64")).toBe("x64");
+    expect(resolveMacosArchiveArch("arm64", "x64")).toBe("x64");
+  });
+
+  test("rejects unsupported architectures", () => {
+    let thrown: unknown;
+    try {
+      resolveMacosArchiveArch("ia32");
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(UpdateCommandError);
+    expect((thrown as UpdateCommandError).code).toBe("update_unsupported_arch");
+  });
+
+  test("extracts sha256 digest from checksum payload", () => {
+    const digest = "a".repeat(64);
+    expect(extractSha256Digest(`${digest}  rem-0.1.0-macos-arm64.tar.gz`)).toBe(digest);
+  });
+
+  test("resolves release archive + checksum assets by version and architecture", () => {
+    const assets = [
+      {
+        name: "rem-0.1.0-macos-arm64.tar.gz",
+        url: "https://example.com/rem-0.1.0-macos-arm64.tar.gz",
+      },
+      {
+        name: "rem-0.1.0-macos-arm64.tar.gz.sha256",
+        url: "https://example.com/rem-0.1.0-macos-arm64.tar.gz.sha256",
+      },
+    ];
+    const resolved = resolveReleaseAssets(assets, "0.1.0", "arm64");
+    expect(resolved.archive.name).toBe("rem-0.1.0-macos-arm64.tar.gz");
+    expect(resolved.checksum.name).toBe("rem-0.1.0-macos-arm64.tar.gz.sha256");
+  });
+
+  test("fails when required release assets are missing", () => {
+    let thrown: unknown;
+    try {
+      resolveReleaseAssets([], "0.1.0", "arm64");
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(UpdateCommandError);
+    expect((thrown as UpdateCommandError).code).toBe("update_asset_not_found");
+  });
+
+  test("prefers root rem package version when executable is not rem", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "rem-update-version-hint-"));
+    const nestedCliDir = path.join(root, "apps", "cli");
+    const fakeExecDir = path.join(root, "fake-bin");
+    const fakeExecPath = path.join(fakeExecDir, "bun");
+
+    try {
+      await mkdir(nestedCliDir, { recursive: true });
+      await mkdir(fakeExecDir, { recursive: true });
+      await Bun.write(path.join(fakeExecDir, "VERSION"), "0.0.0\n");
+      await writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({ name: "rem", version: "0.9.1" }),
+      );
+      await writeFile(
+        path.join(nestedCliDir, "package.json"),
+        JSON.stringify({ name: "@rem-app/cli", version: "0.0.0" }),
+      );
+
+      const resolved = await resolveCurrentVersionHint({
+        env: {},
+        execPath: fakeExecPath,
+        cwd: nestedCliDir,
+      });
+      expect(resolved).toBe("0.9.1");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("uses executable-adjacent VERSION when executable is rem", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "rem-update-version-exec-"));
+    const fakeExecDir = path.join(root, "bundle");
+    const fakeExecPath = path.join(fakeExecDir, "rem");
+
+    try {
+      await mkdir(fakeExecDir, { recursive: true });
+      await Bun.write(path.join(fakeExecDir, "VERSION"), "1.2.3\n");
+
+      const resolved = await resolveCurrentVersionHint({
+        env: {},
+        execPath: fakeExecPath,
+        cwd: root,
+      });
+      expect(resolved).toBe("1.2.3");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/cli/src/update.test.ts
+++ b/apps/cli/src/update.test.ts
@@ -11,6 +11,7 @@ import {
   resolveCurrentVersionHint,
   resolveReleaseAssets,
   resolveReleaseTarget,
+  runRemSelfUpdate,
   runRemSelfUpdateWithInternals,
 } from "./update";
 
@@ -202,6 +203,257 @@ describe("update helpers", () => {
 
     expect(thrown).toBeInstanceOf(UpdateCommandError);
     expect((thrown as UpdateCommandError).code).toBe("update_unsupported_platform");
+  });
+
+  test("fetches latest release metadata via GitHub API by default", async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchCalls: Array<{ input: string; init?: RequestInit }> = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      fetchCalls.push({ input: String(input), init });
+      return new Response(
+        JSON.stringify({
+          tag_name: "v1.2.3",
+          assets: [
+            {
+              name: "rem-1.2.3-linux-x64.tar.gz",
+              browser_download_url: "https://example.com/rem-1.2.3-linux-x64.tar.gz",
+            },
+            {
+              name: "rem-1.2.3-linux-x64.tar.gz.sha256",
+              browser_download_url: "https://example.com/rem-1.2.3-linux-x64.tar.gz.sha256",
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+          },
+        },
+      );
+    }) as unknown as typeof fetch;
+
+    try {
+      const result = await runRemSelfUpdateWithInternals({
+        repo: "ejohane/rem",
+        platform: "linux",
+        processArch: "x64",
+        currentVersion: "1.2.2",
+        check: true,
+        githubToken: "gh-token",
+      });
+
+      expect(result.outcome).toBe("available");
+      expect(fetchCalls[0]?.input).toBe("https://api.github.com/repos/ejohane/rem/releases/latest");
+      expect(fetchCalls[0]?.init?.headers).toEqual({
+        accept: "application/vnd.github+json",
+        authorization: "Bearer gh-token",
+        "user-agent": "rem-cli-update",
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("returns invalid repo when default release fetch receives malformed repo slug", async () => {
+    let thrown: unknown;
+    try {
+      await runRemSelfUpdateWithInternals({
+        repo: "invalid-repo",
+        platform: "linux",
+        processArch: "x64",
+        currentVersion: "1.0.0",
+        check: true,
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(UpdateCommandError);
+    expect((thrown as UpdateCommandError).code).toBe("update_invalid_repo");
+  });
+
+  test("returns parse failure when GitHub payload shape is invalid", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      return new Response(JSON.stringify({ tag_name: "v1.2.3", assets: "invalid" }), {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+        },
+      });
+    }) as unknown as typeof fetch;
+
+    let thrown: unknown;
+    try {
+      await runRemSelfUpdateWithInternals({
+        repo: "ejohane/rem",
+        platform: "linux",
+        processArch: "x64",
+        currentVersion: "1.0.0",
+        check: true,
+      });
+    } catch (error) {
+      thrown = error;
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(thrown).toBeInstanceOf(UpdateCommandError);
+    expect((thrown as UpdateCommandError).code).toBe("update_release_parse_failed");
+  });
+
+  test("returns parse failure when release payload has no downloadable assets", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      return new Response(
+        JSON.stringify({
+          tag_name: "v1.2.3",
+          assets: [{ id: 1 }],
+        }),
+        {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+          },
+        },
+      );
+    }) as unknown as typeof fetch;
+
+    let thrown: unknown;
+    try {
+      await runRemSelfUpdateWithInternals({
+        repo: "ejohane/rem",
+        platform: "linux",
+        processArch: "x64",
+        currentVersion: "1.0.0",
+        check: true,
+      });
+    } catch (error) {
+      thrown = error;
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(thrown).toBeInstanceOf(UpdateCommandError);
+    expect((thrown as UpdateCommandError).code).toBe("update_release_parse_failed");
+  });
+
+  test("returns fetch failure details from GitHub release metadata request", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      return new Response("resource not found", {
+        status: 404,
+        statusText: "Not Found",
+      });
+    }) as unknown as typeof fetch;
+
+    let thrown: unknown;
+    try {
+      await runRemSelfUpdateWithInternals({
+        repo: "ejohane/rem",
+        platform: "linux",
+        processArch: "x64",
+        currentVersion: "1.0.0",
+        check: true,
+      });
+    } catch (error) {
+      thrown = error;
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(thrown).toBeInstanceOf(UpdateCommandError);
+    expect((thrown as UpdateCommandError).code).toBe("update_release_fetch_failed");
+    expect((thrown as UpdateCommandError).message).toContain("resource not found");
+  });
+
+  test("returns release mismatch when requested version resolves to different tag", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      return new Response(
+        JSON.stringify({
+          tag_name: "v1.2.4",
+          assets: [
+            {
+              name: "rem-1.2.4-linux-x64.tar.gz",
+              browser_download_url: "https://example.com/rem-1.2.4-linux-x64.tar.gz",
+            },
+            {
+              name: "rem-1.2.4-linux-x64.tar.gz.sha256",
+              browser_download_url: "https://example.com/rem-1.2.4-linux-x64.tar.gz.sha256",
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+          },
+        },
+      );
+    }) as unknown as typeof fetch;
+
+    let thrown: unknown;
+    try {
+      await runRemSelfUpdateWithInternals({
+        repo: "ejohane/rem",
+        version: "1.2.3",
+        platform: "linux",
+        processArch: "x64",
+        currentVersion: "1.0.0",
+        check: true,
+      });
+    } catch (error) {
+      thrown = error;
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(thrown).toBeInstanceOf(UpdateCommandError);
+    expect((thrown as UpdateCommandError).code).toBe("update_release_mismatch");
+  });
+
+  test("runRemSelfUpdate delegates to the update pipeline", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      return new Response(
+        JSON.stringify({
+          tag_name: "v1.3.0",
+          assets: [
+            {
+              name: "rem-1.3.0-linux-x64.tar.gz",
+              browser_download_url: "https://example.com/rem-1.3.0-linux-x64.tar.gz",
+            },
+            {
+              name: "rem-1.3.0-linux-x64.tar.gz.sha256",
+              browser_download_url: "https://example.com/rem-1.3.0-linux-x64.tar.gz.sha256",
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+          },
+        },
+      );
+    }) as unknown as typeof fetch;
+
+    try {
+      const result = await runRemSelfUpdate({
+        repo: "ejohane/rem",
+        platform: "linux",
+        processArch: "x64",
+        currentVersion: "1.2.0",
+        check: true,
+      });
+
+      expect(result.outcome).toBe("available");
+      expect(result.targetVersion).toBe("1.3.0");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   test("returns up_to_date when current and target versions match", async () => {

--- a/apps/cli/src/update.test.ts
+++ b/apps/cli/src/update.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
+  type RemReleaseLookupResult,
   UpdateCommandError,
   extractSha256Digest,
   extractVersionFromTag,
@@ -10,7 +11,31 @@ import {
   resolveCurrentVersionHint,
   resolveReleaseAssets,
   resolveReleaseTarget,
+  runRemSelfUpdateWithInternals,
 } from "./update";
+
+function releaseFixture(input: {
+  version: string;
+  platform: "macos" | "linux" | "windows";
+  arch: "arm64" | "x64";
+  archiveFormat: "tar.gz" | "zip";
+}): RemReleaseLookupResult {
+  const archiveName = `rem-${input.version}-${input.platform}-${input.arch}.${input.archiveFormat}`;
+  return {
+    tag: `v${input.version}`,
+    version: input.version,
+    assets: [
+      {
+        name: archiveName,
+        url: `https://example.com/${archiveName}`,
+      },
+      {
+        name: `${archiveName}.sha256`,
+        url: `https://example.com/${archiveName}.sha256`,
+      },
+    ],
+  };
+}
 
 describe("update helpers", () => {
   test("normalizes semantic versions with or without leading v", () => {
@@ -177,5 +202,313 @@ describe("update helpers", () => {
 
     expect(thrown).toBeInstanceOf(UpdateCommandError);
     expect((thrown as UpdateCommandError).code).toBe("update_unsupported_platform");
+  });
+
+  test("returns up_to_date when current and target versions match", async () => {
+    const release = releaseFixture({
+      version: "0.2.0",
+      platform: "linux",
+      arch: "x64",
+      archiveFormat: "tar.gz",
+    });
+
+    const result = await runRemSelfUpdateWithInternals(
+      {
+        repo: "ejohane/rem",
+        platform: "linux",
+        processArch: "x64",
+        currentVersion: "0.2.0",
+      },
+      {
+        fetchGithubRelease: async () => release,
+      },
+    );
+
+    expect(result.outcome).toBe("up_to_date");
+    expect(result.installed).toBeFalse();
+    expect(result.platform).toBe("linux");
+    expect(result.archiveName).toBe("rem-0.2.0-linux-x64.tar.gz");
+  });
+
+  test("returns available for check-only update requests", async () => {
+    const release = releaseFixture({
+      version: "0.3.0",
+      platform: "macos",
+      arch: "arm64",
+      archiveFormat: "tar.gz",
+    });
+
+    const result = await runRemSelfUpdateWithInternals(
+      {
+        repo: "ejohane/rem",
+        platform: "darwin",
+        processArch: "arm64",
+        currentVersion: "0.2.0",
+        check: true,
+      },
+      {
+        fetchGithubRelease: async () => release,
+      },
+    );
+
+    expect(result.outcome).toBe("available");
+    expect(result.checkOnly).toBeTrue();
+    expect(result.installed).toBeFalse();
+    expect(result.targetVersion).toBe("0.3.0");
+  });
+
+  test("installs update and runs all install pipeline steps", async () => {
+    const release = releaseFixture({
+      version: "0.4.0",
+      platform: "windows",
+      arch: "x64",
+      archiveFormat: "zip",
+    });
+    const digest = "b".repeat(64);
+    const calls = {
+      downloads: [] as string[],
+      extracts: [] as Array<{ archivePath: string; archiveFormat: "tar.gz" | "zip" }>,
+      installers: [] as Array<{ packageDir: string; args: string[] }>,
+      cleaned: [] as string[],
+    };
+
+    const result = await runRemSelfUpdateWithInternals(
+      {
+        repo: "ejohane/rem",
+        platform: "win32",
+        processArch: "x64",
+        currentVersion: "0.3.0",
+        local: true,
+      },
+      {
+        fetchGithubRelease: async () => release,
+        makeTempDir: async () => "/tmp/rem-update-test",
+        downloadAsset: async (url) => {
+          calls.downloads.push(url);
+        },
+        readTextFile: async () => `${digest}  rem-0.4.0-windows-x64.zip`,
+        computeFileSha256: async () => digest,
+        extractArchive: async (archivePath, _outputDir, archiveFormat) => {
+          calls.extracts.push({ archivePath, archiveFormat });
+        },
+        installerExists: async () => true,
+        runInstaller: async (packageDir, args) => {
+          calls.installers.push({ packageDir, args });
+        },
+        cleanupTempDir: async (tempRoot) => {
+          calls.cleaned.push(tempRoot);
+        },
+      },
+    );
+
+    expect(result.outcome).toBe("installed");
+    expect(result.platform).toBe("win32");
+    expect(result.installed).toBeTrue();
+    expect(calls.downloads.length).toBe(2);
+    expect(calls.extracts[0]?.archiveFormat).toBe("zip");
+    expect(calls.installers[0]?.args).toContain("-Local");
+    expect(calls.cleaned).toEqual(["/tmp/rem-update-test"]);
+  });
+
+  test("supports forced reinstall even when current version matches", async () => {
+    const release = releaseFixture({
+      version: "0.5.0",
+      platform: "linux",
+      arch: "x64",
+      archiveFormat: "tar.gz",
+    });
+    let installCalled = false;
+
+    const result = await runRemSelfUpdateWithInternals(
+      {
+        repo: "ejohane/rem",
+        platform: "linux",
+        processArch: "x64",
+        currentVersion: "0.5.0",
+        force: true,
+      },
+      {
+        fetchGithubRelease: async () => release,
+        makeTempDir: async () => "/tmp/rem-update-force",
+        downloadAsset: async () => {},
+        readTextFile: async () => `${"c".repeat(64)}  rem-0.5.0-linux-x64.tar.gz`,
+        computeFileSha256: async () => "c".repeat(64),
+        extractArchive: async () => {},
+        installerExists: async () => true,
+        runInstaller: async () => {
+          installCalled = true;
+        },
+        cleanupTempDir: async () => {},
+      },
+    );
+
+    expect(result.outcome).toBe("installed");
+    expect(result.forced).toBeTrue();
+    expect(installCalled).toBeTrue();
+  });
+
+  test("returns checksum mismatch error and still cleans temp directory", async () => {
+    const release = releaseFixture({
+      version: "0.6.0",
+      platform: "linux",
+      arch: "x64",
+      archiveFormat: "tar.gz",
+    });
+    const cleaned: string[] = [];
+
+    let thrown: unknown;
+    try {
+      await runRemSelfUpdateWithInternals(
+        {
+          repo: "ejohane/rem",
+          platform: "linux",
+          processArch: "x64",
+          currentVersion: "0.5.0",
+        },
+        {
+          fetchGithubRelease: async () => release,
+          makeTempDir: async () => "/tmp/rem-update-checksum",
+          downloadAsset: async () => {},
+          readTextFile: async () => `${"d".repeat(64)}  rem-0.6.0-linux-x64.tar.gz`,
+          computeFileSha256: async () => "e".repeat(64),
+          cleanupTempDir: async (tempRoot) => {
+            cleaned.push(tempRoot);
+          },
+        },
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(UpdateCommandError);
+    expect((thrown as UpdateCommandError).code).toBe("update_checksum_mismatch");
+    expect(cleaned).toEqual(["/tmp/rem-update-checksum"]);
+  });
+
+  test("returns installer missing when extracted package lacks installer", async () => {
+    const release = releaseFixture({
+      version: "0.7.0",
+      platform: "windows",
+      arch: "x64",
+      archiveFormat: "zip",
+    });
+    let thrown: unknown;
+    try {
+      await runRemSelfUpdateWithInternals(
+        {
+          repo: "ejohane/rem",
+          platform: "win32",
+          processArch: "x64",
+          currentVersion: "0.6.0",
+        },
+        {
+          fetchGithubRelease: async () => release,
+          makeTempDir: async () => "/tmp/rem-update-installer-missing",
+          downloadAsset: async () => {},
+          readTextFile: async () => `${"f".repeat(64)}  rem-0.7.0-windows-x64.zip`,
+          computeFileSha256: async () => "f".repeat(64),
+          extractArchive: async () => {},
+          installerExists: async () => false,
+          cleanupTempDir: async () => {},
+        },
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(UpdateCommandError);
+    expect((thrown as UpdateCommandError).code).toBe("update_installer_missing");
+  });
+
+  test("returns install failure when installer execution fails", async () => {
+    const release = releaseFixture({
+      version: "0.8.0",
+      platform: "linux",
+      arch: "x64",
+      archiveFormat: "tar.gz",
+    });
+    let thrown: unknown;
+    try {
+      await runRemSelfUpdateWithInternals(
+        {
+          repo: "ejohane/rem",
+          platform: "linux",
+          processArch: "x64",
+          currentVersion: "0.7.0",
+        },
+        {
+          fetchGithubRelease: async () => release,
+          makeTempDir: async () => "/tmp/rem-update-install-fail",
+          downloadAsset: async () => {},
+          readTextFile: async () => `${"a".repeat(64)}  rem-0.8.0-linux-x64.tar.gz`,
+          computeFileSha256: async () => "a".repeat(64),
+          extractArchive: async () => {},
+          installerExists: async () => true,
+          runInstaller: async () => {
+            throw new UpdateCommandError("update_install_failed", "installer failure");
+          },
+          cleanupTempDir: async () => {},
+        },
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(UpdateCommandError);
+    expect((thrown as UpdateCommandError).code).toBe("update_install_failed");
+  });
+
+  test("returns release fetch errors from the release lookup step", async () => {
+    let thrown: unknown;
+    try {
+      await runRemSelfUpdateWithInternals(
+        {
+          repo: "ejohane/rem",
+          platform: "linux",
+          processArch: "x64",
+          currentVersion: "0.1.0",
+        },
+        {
+          fetchGithubRelease: async () => {
+            throw new UpdateCommandError("update_release_fetch_failed", "fetch failed");
+          },
+        },
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(UpdateCommandError);
+    expect((thrown as UpdateCommandError).code).toBe("update_release_fetch_failed");
+  });
+
+  test("returns invalid options when local is combined with install-dir", async () => {
+    const release = releaseFixture({
+      version: "0.9.0",
+      platform: "linux",
+      arch: "x64",
+      archiveFormat: "tar.gz",
+    });
+    let thrown: unknown;
+    try {
+      await runRemSelfUpdateWithInternals(
+        {
+          repo: "ejohane/rem",
+          platform: "linux",
+          processArch: "x64",
+          currentVersion: "0.8.0",
+          local: true,
+          installDir: "/tmp/rem",
+        },
+        {
+          fetchGithubRelease: async () => release,
+        },
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(UpdateCommandError);
+    expect((thrown as UpdateCommandError).code).toBe("update_invalid_options");
   });
 });

--- a/apps/cli/src/update.ts
+++ b/apps/cli/src/update.ts
@@ -1,0 +1,518 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const semverPattern = /^\d+\.\d+\.\d+$/;
+const repoPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const githubApiBaseUrl = "https://api.github.com";
+
+export type MacosArchiveArch = "arm64" | "x64";
+
+export interface ReleaseAsset {
+  name: string;
+  url: string;
+}
+
+interface GithubReleaseRecord {
+  tag: string;
+  version: string;
+  assets: ReleaseAsset[];
+}
+
+interface ReleaseAssetPair {
+  archive: ReleaseAsset;
+  checksum: ReleaseAsset;
+}
+
+export class UpdateCommandError extends Error {
+  code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+    this.name = "UpdateCommandError";
+  }
+}
+
+export interface RemSelfUpdateInput {
+  repo: string;
+  version?: string;
+  arch?: string;
+  installDir?: string;
+  binDir?: string;
+  local?: boolean;
+  check?: boolean;
+  force?: boolean;
+  platform?: NodeJS.Platform;
+  processArch?: string;
+  currentVersion?: string | null;
+  githubToken?: string;
+}
+
+export interface RemSelfUpdateResult {
+  outcome: "up_to_date" | "available" | "installed";
+  repo: string;
+  tag: string;
+  currentVersion: string | null;
+  targetVersion: string;
+  arch: MacosArchiveArch;
+  archiveName: string;
+  checkOnly: boolean;
+  installed: boolean;
+  forced: boolean;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function normalizeSemverInput(raw: string, context: string): string {
+  const trimmed = raw.trim();
+  const withoutPrefix = trimmed.startsWith("v") ? trimmed.slice(1) : trimmed;
+  if (!semverPattern.test(withoutPrefix)) {
+    throw new UpdateCommandError(
+      "update_invalid_version",
+      `${context} must be semantic (MAJOR.MINOR.PATCH), got: ${raw}`,
+    );
+  }
+
+  return withoutPrefix;
+}
+
+export function extractVersionFromTag(tag: string): string {
+  return normalizeSemverInput(tag, "Release tag");
+}
+
+export function resolveMacosArchiveArch(
+  processArch: string,
+  archOverride?: string,
+): MacosArchiveArch {
+  if (archOverride) {
+    const normalized = archOverride.trim();
+    if (normalized === "arm64" || normalized === "x64") {
+      return normalized;
+    }
+    throw new UpdateCommandError(
+      "update_invalid_arch",
+      `Invalid --arch value: ${archOverride}. Expected: arm64|x64`,
+    );
+  }
+
+  if (processArch === "arm64") {
+    return "arm64";
+  }
+  if (processArch === "x64") {
+    return "x64";
+  }
+
+  throw new UpdateCommandError(
+    "update_unsupported_arch",
+    `Unsupported architecture for macOS package updates: ${processArch}`,
+  );
+}
+
+export function extractSha256Digest(content: string): string {
+  const match = content.match(/\b([a-fA-F0-9]{64})\b/);
+  if (!match) {
+    throw new UpdateCommandError(
+      "update_invalid_checksum",
+      "Checksum file does not contain a valid SHA-256 digest.",
+    );
+  }
+
+  return match[1].toLowerCase();
+}
+
+export function resolveReleaseAssets(
+  assets: ReleaseAsset[],
+  version: string,
+  arch: MacosArchiveArch,
+): ReleaseAssetPair {
+  const archiveName = `rem-${version}-macos-${arch}.tar.gz`;
+  const checksumName = `${archiveName}.sha256`;
+  const archive = assets.find((asset) => asset.name === archiveName);
+  const checksum = assets.find((asset) => asset.name === checksumName);
+
+  if (!archive || !checksum) {
+    throw new UpdateCommandError(
+      "update_asset_not_found",
+      `Release assets missing for ${archiveName} and/or ${checksumName}.`,
+    );
+  }
+
+  return {
+    archive,
+    checksum,
+  };
+}
+
+export async function resolveCurrentVersionHint(input?: {
+  env?: Record<string, string | undefined>;
+  execPath?: string;
+  cwd?: string;
+}): Promise<string | null> {
+  const env = input?.env ?? process.env;
+  const execPath = input?.execPath ?? process.execPath;
+  const cwd = input?.cwd ?? process.cwd();
+
+  const fromEnv = env.REM_VERSION?.trim();
+  if (fromEnv) {
+    try {
+      return normalizeSemverInput(fromEnv, "Installed version");
+    } catch {
+      // Ignore invalid env override and continue probing.
+    }
+  }
+
+  const versionFiles: string[] = [];
+  const executableName = path.basename(execPath).toLowerCase();
+  if (executableName === "rem" || executableName === "rem.exe") {
+    versionFiles.push(path.join(path.dirname(execPath), "VERSION"));
+  }
+  versionFiles.push(path.join(cwd, "VERSION"));
+  for (const versionPath of versionFiles) {
+    const file = Bun.file(versionPath);
+    if (!(await file.exists())) {
+      continue;
+    }
+
+    const content = (await file.text()).trim();
+    if (!content) {
+      continue;
+    }
+
+    try {
+      return normalizeSemverInput(content, "Installed version");
+    } catch {
+      // Keep probing if the file content is malformed.
+    }
+  }
+
+  let scanDir = cwd;
+  while (true) {
+    const packageJsonPath = path.join(scanDir, "package.json");
+    const packageFile = Bun.file(packageJsonPath);
+    if (await packageFile.exists()) {
+      try {
+        const payload = JSON.parse(await packageFile.text()) as {
+          name?: unknown;
+          version?: unknown;
+        };
+        if (payload.name === "rem" && typeof payload.version === "string") {
+          return normalizeSemverInput(payload.version, "package.json version");
+        }
+      } catch {
+        // Continue scanning parent directories when parse fails.
+      }
+    }
+
+    const parentDir = path.dirname(scanDir);
+    if (parentDir === scanDir) {
+      break;
+    }
+    scanDir = parentDir;
+  }
+
+  return null;
+}
+
+function encodeRepoSlug(repo: string): string {
+  const parts = repo.split("/");
+  return `${encodeURIComponent(parts[0] ?? "")}/${encodeURIComponent(parts[1] ?? "")}`;
+}
+
+function buildGithubHeaders(token?: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    accept: "application/vnd.github+json",
+    "user-agent": "rem-cli-update",
+  };
+  if (token) {
+    headers.authorization = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+function parseGithubReleasePayload(payload: unknown): GithubReleaseRecord {
+  if (!isPlainObject(payload)) {
+    throw new UpdateCommandError("update_release_parse_failed", "Invalid GitHub release payload.");
+  }
+
+  const tagName = payload.tag_name;
+  const rawAssets = payload.assets;
+  if (typeof tagName !== "string" || !Array.isArray(rawAssets)) {
+    throw new UpdateCommandError("update_release_parse_failed", "Invalid GitHub release payload.");
+  }
+
+  const assets: ReleaseAsset[] = [];
+  for (const entry of rawAssets) {
+    if (!isPlainObject(entry)) {
+      continue;
+    }
+    if (typeof entry.name !== "string" || typeof entry.browser_download_url !== "string") {
+      continue;
+    }
+    assets.push({
+      name: entry.name,
+      url: entry.browser_download_url,
+    });
+  }
+
+  if (assets.length === 0) {
+    throw new UpdateCommandError(
+      "update_release_parse_failed",
+      "GitHub release payload did not include downloadable assets.",
+    );
+  }
+
+  const version = extractVersionFromTag(tagName);
+  return {
+    tag: tagName,
+    version,
+    assets,
+  };
+}
+
+async function fetchGithubRelease(
+  repo: string,
+  requestedVersion: string | undefined,
+  token: string | undefined,
+): Promise<GithubReleaseRecord> {
+  if (!repoPattern.test(repo)) {
+    throw new UpdateCommandError(
+      "update_invalid_repo",
+      `Invalid --repo value: ${repo}. Expected owner/repo.`,
+    );
+  }
+
+  const encodedRepo = encodeRepoSlug(repo);
+  const endpoint = requestedVersion
+    ? `${githubApiBaseUrl}/repos/${encodedRepo}/releases/tags/v${requestedVersion}`
+    : `${githubApiBaseUrl}/repos/${encodedRepo}/releases/latest`;
+
+  const response = await fetch(endpoint, {
+    headers: buildGithubHeaders(token),
+  });
+  if (!response.ok) {
+    let bodyText = "";
+    try {
+      bodyText = (await response.text()).trim();
+    } catch {
+      // Ignore parse failures for error response body.
+    }
+
+    const details = bodyText ? ` ${bodyText}` : "";
+    throw new UpdateCommandError(
+      "update_release_fetch_failed",
+      `Failed to fetch GitHub release metadata (${response.status} ${response.statusText}).${details}`,
+    );
+  }
+
+  const payload = parseGithubReleasePayload(await response.json());
+  if (requestedVersion && payload.version !== requestedVersion) {
+    throw new UpdateCommandError(
+      "update_release_mismatch",
+      `Requested version ${requestedVersion} resolved to tag ${payload.tag}.`,
+    );
+  }
+
+  return payload;
+}
+
+async function downloadAsset(url: string, destinationPath: string, token?: string): Promise<void> {
+  const response = await fetch(url, {
+    headers: buildGithubHeaders(token),
+  });
+  if (!response.ok) {
+    throw new UpdateCommandError(
+      "update_download_failed",
+      `Failed to download asset (${response.status} ${response.statusText}): ${url}`,
+    );
+  }
+
+  const bytes = await response.arrayBuffer();
+  await Bun.write(destinationPath, bytes);
+}
+
+async function computeFileSha256(filePath: string): Promise<string> {
+  const bytes = await Bun.file(filePath).arrayBuffer();
+  return createHash("sha256").update(Buffer.from(bytes)).digest("hex");
+}
+
+function trimOutput(output: Uint8Array | undefined | null): string {
+  return Buffer.from(output ?? new Uint8Array())
+    .toString("utf8")
+    .trim();
+}
+
+async function extractArchive(archivePath: string, outputDir: string): Promise<void> {
+  const extractResult = Bun.spawnSync(["tar", "-xzf", archivePath], {
+    cwd: outputDir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (extractResult.exitCode === 0) {
+    return;
+  }
+
+  const stderr = trimOutput(extractResult.stderr);
+  const stdout = trimOutput(extractResult.stdout);
+  const details = stderr || stdout || "tar extraction failed";
+  throw new UpdateCommandError("update_extract_failed", details);
+}
+
+function buildInstallerArgs(options: {
+  local?: boolean;
+  installDir?: string;
+  binDir?: string;
+}): string[] {
+  if (options.local && (options.installDir || options.binDir)) {
+    throw new UpdateCommandError(
+      "update_invalid_options",
+      "--local cannot be combined with --install-dir or --bin-dir.",
+    );
+  }
+
+  const args = ["./install.sh"];
+  if (options.installDir) {
+    args.push("--install-dir", options.installDir);
+  }
+  if (options.binDir) {
+    args.push("--bin-dir", options.binDir);
+  }
+  if (options.local) {
+    args.push("--local");
+  }
+
+  return args;
+}
+
+async function runInstaller(packageDir: string, args: string[]): Promise<void> {
+  const installResult = Bun.spawnSync(["bash", ...args], {
+    cwd: packageDir,
+    stdin: "inherit",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: process.env,
+  });
+
+  if (installResult.exitCode === 0) {
+    return;
+  }
+
+  const stderr = trimOutput(installResult.stderr);
+  const stdout = trimOutput(installResult.stdout);
+  let message = stderr || stdout || `Installer exited with code ${installResult.exitCode}`;
+  if (/permission denied|operation not permitted/i.test(message)) {
+    message = `${message}\nTry running with elevated permissions or use --local.`;
+  }
+  throw new UpdateCommandError("update_install_failed", message);
+}
+
+export async function runRemSelfUpdate(input: RemSelfUpdateInput): Promise<RemSelfUpdateResult> {
+  const platform = input.platform ?? process.platform;
+  if (platform !== "darwin") {
+    throw new UpdateCommandError(
+      "update_unsupported_platform",
+      `rem update currently supports macOS only (detected: ${platform}).`,
+    );
+  }
+
+  const repo = input.repo.trim();
+  const requestedVersion = input.version
+    ? normalizeSemverInput(input.version, "Target version")
+    : undefined;
+  const arch = resolveMacosArchiveArch(input.processArch ?? process.arch, input.arch);
+  const currentVersion =
+    input.currentVersion === undefined ? await resolveCurrentVersionHint() : input.currentVersion;
+  const release = await fetchGithubRelease(repo, requestedVersion, input.githubToken);
+  const assets = resolveReleaseAssets(release.assets, release.version, arch);
+  const checkOnly = Boolean(input.check);
+  const forceInstall = Boolean(input.force);
+
+  const upToDate = currentVersion !== null && currentVersion === release.version;
+  if (upToDate && !forceInstall) {
+    return {
+      outcome: "up_to_date",
+      repo,
+      tag: release.tag,
+      currentVersion,
+      targetVersion: release.version,
+      arch,
+      archiveName: assets.archive.name,
+      checkOnly,
+      installed: false,
+      forced: forceInstall,
+    };
+  }
+
+  if (checkOnly) {
+    return {
+      outcome: "available",
+      repo,
+      tag: release.tag,
+      currentVersion,
+      targetVersion: release.version,
+      arch,
+      archiveName: assets.archive.name,
+      checkOnly: true,
+      installed: false,
+      forced: forceInstall,
+    };
+  }
+
+  const installerArgs = buildInstallerArgs({
+    local: input.local,
+    installDir: input.installDir,
+    binDir: input.binDir,
+  });
+
+  let tempRoot: string | null = null;
+  try {
+    tempRoot = await mkdtemp(path.join(tmpdir(), "rem-update-"));
+    const archivePath = path.join(tempRoot, assets.archive.name);
+    const checksumPath = path.join(tempRoot, assets.checksum.name);
+
+    await downloadAsset(assets.archive.url, archivePath, input.githubToken);
+    await downloadAsset(assets.checksum.url, checksumPath, input.githubToken);
+
+    const expectedSha = extractSha256Digest(await Bun.file(checksumPath).text());
+    const actualSha = await computeFileSha256(archivePath);
+    if (expectedSha !== actualSha) {
+      throw new UpdateCommandError(
+        "update_checksum_mismatch",
+        `Checksum mismatch for ${assets.archive.name}.`,
+      );
+    }
+
+    await extractArchive(archivePath, tempRoot);
+
+    const packageDir = path.join(tempRoot, assets.archive.name.replace(/\.tar\.gz$/, ""));
+    const installerPath = path.join(packageDir, "install.sh");
+    if (!(await Bun.file(installerPath).exists())) {
+      throw new UpdateCommandError(
+        "update_installer_missing",
+        `Expected installer not found in package: ${installerPath}`,
+      );
+    }
+
+    await runInstaller(packageDir, installerArgs);
+  } finally {
+    if (tempRoot) {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  }
+
+  return {
+    outcome: "installed",
+    repo,
+    tag: release.tag,
+    currentVersion,
+    targetVersion: release.version,
+    arch,
+    archiveName: assets.archive.name,
+    checkOnly: false,
+    installed: true,
+    forced: forceInstall,
+  };
+}

--- a/apps/cli/src/update.ts
+++ b/apps/cli/src/update.ts
@@ -33,6 +33,12 @@ interface GithubReleaseRecord {
   assets: ReleaseAsset[];
 }
 
+export interface RemReleaseLookupResult {
+  tag: string;
+  version: string;
+  assets: ReleaseAsset[];
+}
+
 interface ReleaseAssetPair {
   archive: ReleaseAsset;
   checksum: ReleaseAsset;
@@ -75,6 +81,27 @@ export interface RemSelfUpdateResult {
   checkOnly: boolean;
   installed: boolean;
   forced: boolean;
+}
+
+export interface RemSelfUpdateInternals {
+  resolveCurrentVersionHint?: () => Promise<string | null>;
+  fetchGithubRelease?: (
+    repo: string,
+    requestedVersion: string | undefined,
+    token: string | undefined,
+  ) => Promise<RemReleaseLookupResult>;
+  downloadAsset?: (url: string, destinationPath: string, token?: string) => Promise<void>;
+  readTextFile?: (filePath: string) => Promise<string>;
+  computeFileSha256?: (filePath: string) => Promise<string>;
+  extractArchive?: (
+    archivePath: string,
+    outputDir: string,
+    archiveFormat: "tar.gz" | "zip",
+  ) => Promise<void>;
+  installerExists?: (installerPath: string) => Promise<boolean>;
+  runInstaller?: (packageDir: string, args: string[]) => Promise<void>;
+  makeTempDir?: (prefix: string) => Promise<string>;
+  cleanupTempDir?: (tempRoot: string) => Promise<void>;
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -339,7 +366,7 @@ async function fetchGithubRelease(
   repo: string,
   requestedVersion: string | undefined,
   token: string | undefined,
-): Promise<GithubReleaseRecord> {
+): Promise<RemReleaseLookupResult> {
   if (!repoPattern.test(repo)) {
     throw new UpdateCommandError(
       "update_invalid_repo",
@@ -550,7 +577,31 @@ function resolvePackageDirFromArchiveName(
 }
 
 export async function runRemSelfUpdate(input: RemSelfUpdateInput): Promise<RemSelfUpdateResult> {
+  return runRemSelfUpdateWithInternals(input);
+}
+
+export async function runRemSelfUpdateWithInternals(
+  input: RemSelfUpdateInput,
+  internals: RemSelfUpdateInternals = {},
+): Promise<RemSelfUpdateResult> {
   const runtimePlatform = input.platform ?? process.platform;
+  const resolveCurrentVersion = internals.resolveCurrentVersionHint ?? resolveCurrentVersionHint;
+  const fetchRelease = internals.fetchGithubRelease ?? fetchGithubRelease;
+  const download = internals.downloadAsset ?? downloadAsset;
+  const readTextFile =
+    internals.readTextFile ?? (async (filePath: string) => Bun.file(filePath).text());
+  const computeSha = internals.computeFileSha256 ?? computeFileSha256;
+  const extract =
+    internals.extractArchive ??
+    (async (archivePath: string, outputDir: string, archiveFormat: "tar.gz" | "zip") =>
+      extractArchive(archivePath, outputDir, archiveFormat));
+  const installerExists =
+    internals.installerExists ??
+    (async (installerPath: string) => Bun.file(installerPath).exists());
+  const makeTempDir = internals.makeTempDir ?? mkdtemp;
+  const cleanupTempDir =
+    internals.cleanupTempDir ??
+    (async (tempRoot: string) => rm(tempRoot, { recursive: true, force: true }));
 
   const repo = input.repo.trim();
   const requestedVersion = input.version
@@ -562,8 +613,8 @@ export async function runRemSelfUpdate(input: RemSelfUpdateInput): Promise<RemSe
     input.arch,
   );
   const currentVersion =
-    input.currentVersion === undefined ? await resolveCurrentVersionHint() : input.currentVersion;
-  const release = await fetchGithubRelease(repo, requestedVersion, input.githubToken);
+    input.currentVersion === undefined ? await resolveCurrentVersion() : input.currentVersion;
+  const release = await fetchRelease(repo, requestedVersion, input.githubToken);
   const assets = resolveReleaseAssets(release.assets, release.version, target);
   const checkOnly = Boolean(input.check);
   const forceInstall = Boolean(input.force);
@@ -609,15 +660,15 @@ export async function runRemSelfUpdate(input: RemSelfUpdateInput): Promise<RemSe
 
   let tempRoot: string | null = null;
   try {
-    tempRoot = await mkdtemp(path.join(tmpdir(), "rem-update-"));
+    tempRoot = await makeTempDir(path.join(tmpdir(), "rem-update-"));
     const archivePath = path.join(tempRoot, assets.archive.name);
     const checksumPath = path.join(tempRoot, assets.checksum.name);
 
-    await downloadAsset(assets.archive.url, archivePath, input.githubToken);
-    await downloadAsset(assets.checksum.url, checksumPath, input.githubToken);
+    await download(assets.archive.url, archivePath, input.githubToken);
+    await download(assets.checksum.url, checksumPath, input.githubToken);
 
-    const expectedSha = extractSha256Digest(await Bun.file(checksumPath).text());
-    const actualSha = await computeFileSha256(archivePath);
+    const expectedSha = extractSha256Digest(await readTextFile(checksumPath));
+    const actualSha = await computeSha(archivePath);
     if (expectedSha !== actualSha) {
       throw new UpdateCommandError(
         "update_checksum_mismatch",
@@ -625,7 +676,7 @@ export async function runRemSelfUpdate(input: RemSelfUpdateInput): Promise<RemSe
       );
     }
 
-    await extractArchive(archivePath, tempRoot, target.archiveFormat);
+    await extract(archivePath, tempRoot, target.archiveFormat);
 
     const packageDir = resolvePackageDirFromArchiveName(
       tempRoot,
@@ -633,17 +684,21 @@ export async function runRemSelfUpdate(input: RemSelfUpdateInput): Promise<RemSe
       target.archiveFormat,
     );
     const installerPath = path.join(packageDir, target.installerFile);
-    if (!(await Bun.file(installerPath).exists())) {
+    if (!(await installerExists(installerPath))) {
       throw new UpdateCommandError(
         "update_installer_missing",
         `Expected installer not found in package: ${installerPath}`,
       );
     }
 
-    await runInstaller(packageDir, target.installerKind, installerArgs);
+    if (internals.runInstaller) {
+      await internals.runInstaller(packageDir, installerArgs);
+    } else {
+      await runInstaller(packageDir, target.installerKind, installerArgs);
+    }
   } finally {
     if (tempRoot) {
-      await rm(tempRoot, { recursive: true, force: true });
+      await cleanupTempDir(tempRoot);
     }
   }
 

--- a/docs/api-cli-reference.md
+++ b/docs/api-cli-reference.md
@@ -180,18 +180,20 @@ Use `bun run --cwd apps/cli src/index.ts ...` in source checkouts.
 | Index | `rebuild-index --json` | Rebuild derived index |
 | Skills | `skill list` / `skill install <skill-id> --json` | List/install bundled canned agent skills |
 | Runtime | `api` / `app` | Launch API-only or API+UI runtime |
-| Runtime | `update ... [--check|--force] [--json]` | Update macOS binary install from GitHub releases |
+| Runtime | `update ... [--check|--force] [--json]` | Update platform binary install from GitHub releases |
 
-## CLI binary update (macOS)
+## CLI binary update (darwin/linux/win32)
 
-`update` installs release tarballs in place by downloading:
+`update` installs platform release artifacts in place by downloading:
 - `rem-<version>-macos-<arch>.tar.gz`
-- `rem-<version>-macos-<arch>.tar.gz.sha256`
+- `rem-<version>-linux-<arch>.tar.gz`
+- `rem-<version>-windows-<arch>.zip`
+- corresponding `.sha256` checksum asset
 
 Behavior:
 - resolves target version from `--version` or latest release
 - verifies checksum before extraction/install
-- runs package `install.sh` with selected install options
+- runs package installer (`install.sh` on macOS/Linux, `install.ps1` on Windows)
 - checks installed version (from `REM_VERSION`, `VERSION`, or `package.json`) and skips when already current unless `--force`
 
 Options:
@@ -199,7 +201,7 @@ Options:
 - `--version <MAJOR.MINOR.PATCH>` (optional)
 - `--arch <arm64|x64>` (optional override)
 - `--install-dir <path>` and `--bin-dir <path>` (optional installer overrides)
-- `--local` (install to `$HOME/.local/...`; cannot be combined with custom dirs)
+- `--local` (install to user-local defaults; cannot be combined with custom dirs)
 - `--check` (no install; report availability)
 - `--force` (reinstall even when current version matches target)
 - `--json` (machine-readable output)
@@ -252,7 +254,10 @@ CLI update command error codes:
 - `update_invalid_repo`
 - `update_invalid_version`
 - `update_invalid_arch`
+- `update_unsupported_arch`
+- `update_invalid_options`
 - `update_release_fetch_failed`
+- `update_release_parse_failed`
 - `update_asset_not_found`
 - `update_download_failed`
 - `update_invalid_checksum`

--- a/docs/api-cli-reference.md
+++ b/docs/api-cli-reference.md
@@ -1,4 +1,5 @@
 # rem API and CLI Reference
+**Last updated:** 2026-02-22
 
 **Last updated:** 2026-02-22
 
@@ -179,6 +180,29 @@ Use `bun run --cwd apps/cli src/index.ts ...` in source checkouts.
 | Index | `rebuild-index --json` | Rebuild derived index |
 | Skills | `skill list` / `skill install <skill-id> --json` | List/install bundled canned agent skills |
 | Runtime | `api` / `app` | Launch API-only or API+UI runtime |
+| Runtime | `update ... [--check|--force] [--json]` | Update macOS binary install from GitHub releases |
+
+## CLI binary update (macOS)
+
+`update` installs release tarballs in place by downloading:
+- `rem-<version>-macos-<arch>.tar.gz`
+- `rem-<version>-macos-<arch>.tar.gz.sha256`
+
+Behavior:
+- resolves target version from `--version` or latest release
+- verifies checksum before extraction/install
+- runs package `install.sh` with selected install options
+- checks installed version (from `REM_VERSION`, `VERSION`, or `package.json`) and skips when already current unless `--force`
+
+Options:
+- `--repo <owner/repo>` (default: `ejohane/rem`)
+- `--version <MAJOR.MINOR.PATCH>` (optional)
+- `--arch <arm64|x64>` (optional override)
+- `--install-dir <path>` and `--bin-dir <path>` (optional installer overrides)
+- `--local` (install to `$HOME/.local/...`; cannot be combined with custom dirs)
+- `--check` (no install; report availability)
+- `--force` (reinstall even when current version matches target)
+- `--json` (machine-readable output)
 
 ## Runtime guardrails and trust options
 
@@ -223,6 +247,20 @@ Plugin action runtime error codes (API and CLI parity):
 - `plugin_concurrency_limited`
 - `plugin_run_failed`
 
+CLI update command error codes:
+- `update_unsupported_platform`
+- `update_invalid_repo`
+- `update_invalid_version`
+- `update_invalid_arch`
+- `update_release_fetch_failed`
+- `update_asset_not_found`
+- `update_download_failed`
+- `update_invalid_checksum`
+- `update_checksum_mismatch`
+- `update_extract_failed`
+- `update_installer_missing`
+- `update_install_failed`
+
 ## Examples
 
 ### Install bundled umbrella canned skill (CLI)
@@ -237,6 +275,13 @@ bun run --cwd apps/cli src/index.ts skill install rem-cli-memory --json
 ```bash
 bun run --cwd apps/cli src/index.ts plugin install --manifest ./plugin-manifest.json --json
 bun run --cwd apps/cli src/index.ts plugin enable my-plugin --json
+```
+
+### Check and apply binary update (CLI)
+
+```bash
+bun run --cwd apps/cli src/index.ts update --check --json
+bun run --cwd apps/cli src/index.ts update --json
 ```
 
 ### Run plugin action with runtime guards (CLI)

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,4 +1,5 @@
 # rem Operator Runbook
+**Last updated:** 2026-02-22
 
 This runbook covers local operation of rem across notes, proposals, plugins, scheduler runtime, entities, and rebuild workflows.
 
@@ -22,6 +23,25 @@ bun run --cwd apps/ui dev
 ```
 
 Default API: `http://127.0.0.1:8787`
+
+## Binary upgrade workflow (macOS CLI)
+
+```bash
+# Check whether a newer binary package is available
+bun run --cwd apps/cli src/index.ts update --check --json
+
+# Install the latest release in place (default install dirs)
+bun run --cwd apps/cli src/index.ts update --json
+
+# Local user install (no sudo)
+bun run --cwd apps/cli src/index.ts update --local --json
+```
+
+Operational notes:
+- `update` verifies release checksums before running package installer.
+- `update` skips install when current version already matches target unless `--force` is set.
+- default package source is GitHub release assets from `ejohane/rem`; override with `--repo` when needed.
+- `update` currently supports macOS package artifacts only.
 
 Optional API auth:
 - export `REM_API_TOKEN` before starting API

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -24,7 +24,7 @@ bun run --cwd apps/ui dev
 
 Default API: `http://127.0.0.1:8787`
 
-## Binary upgrade workflow (macOS CLI)
+## Binary upgrade workflow (CLI)
 
 ```bash
 # Check whether a newer binary package is available
@@ -41,7 +41,7 @@ Operational notes:
 - `update` verifies release checksums before running package installer.
 - `update` skips install when current version already matches target unless `--force` is set.
 - default package source is GitHub release assets from `ejohane/rem`; override with `--repo` when needed.
-- `update` currently supports macOS package artifacts only.
+- `update` supports release artifacts on `darwin`, `linux`, and `win32`.
 
 Optional API auth:
 - export `REM_API_TOKEN` before starting API

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "version:next-tag": "bun run scripts/semver-version.ts --next-release-tag",
     "version:check": "bun run scripts/semver-version.ts --check-increment",
     "package:macos": "./scripts/package-macos.sh",
+    "package:linux": "./scripts/package-linux.sh",
+    "package:windows": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/package-windows.ps1",
     "typecheck": "bunx tsc --noEmit -p tsconfig.typecheck.json",
     "test": "bun test --pass-with-no-tests",
     "test:coverage": "bun test --coverage --coverage-reporter=lcov --pass-with-no-tests",

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_DIR="$SCRIPT_DIR"
+
+INSTALL_DIR="${REM_INSTALL_DIR:-/opt/rem}"
+BIN_DIR="${REM_BIN_DIR:-/usr/local/bin}"
+
+usage() {
+  cat <<'EOF'
+Install rem from an extracted Linux package directory.
+
+Usage:
+  ./install.sh [--install-dir <path>] [--bin-dir <path>] [--local]
+
+Options:
+  --install-dir <path>  Install binaries/assets into this directory.
+                        Default: /opt/rem (or $REM_INSTALL_DIR)
+  --bin-dir <path>      Write the launcher script to this directory.
+                        Default: /usr/local/bin (or $REM_BIN_DIR)
+  --local               Install without sudo into:
+                        install dir: $HOME/.local/share/rem
+                        bin dir:     $HOME/.local/bin
+  -h, --help            Show this help message.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --install-dir)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --install-dir" >&2
+        exit 1
+      fi
+      INSTALL_DIR="$2"
+      shift 2
+      ;;
+    --bin-dir)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --bin-dir" >&2
+        exit 1
+      fi
+      BIN_DIR="$2"
+      shift 2
+      ;;
+    --local)
+      INSTALL_DIR="$HOME/.local/share/rem"
+      BIN_DIR="$HOME/.local/bin"
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+for required in "rem" "rem-api" "ui-dist/index.html"; do
+  if [[ ! -e "$PACKAGE_DIR/$required" ]]; then
+    echo "Expected package file missing: $PACKAGE_DIR/$required" >&2
+    exit 1
+  fi
+done
+
+mkdir -p "$INSTALL_DIR" "$BIN_DIR"
+
+cp "$PACKAGE_DIR/rem" "$INSTALL_DIR/rem"
+cp "$PACKAGE_DIR/rem-api" "$INSTALL_DIR/rem-api"
+rm -rf "$INSTALL_DIR/ui-dist"
+cp -R "$PACKAGE_DIR/ui-dist" "$INSTALL_DIR/ui-dist"
+if [[ -f "$PACKAGE_DIR/VERSION" ]]; then
+  cp "$PACKAGE_DIR/VERSION" "$INSTALL_DIR/VERSION"
+fi
+if [[ -f "$PACKAGE_DIR/README.md" ]]; then
+  cp "$PACKAGE_DIR/README.md" "$INSTALL_DIR/README.md"
+fi
+
+chmod +x "$INSTALL_DIR/rem" "$INSTALL_DIR/rem-api"
+
+LAUNCHER_PATH="$BIN_DIR/rem"
+cat >"$LAUNCHER_PATH" <<EOF
+#!/bin/sh
+export REM_API_BINARY="$INSTALL_DIR/rem-api"
+export REM_UI_DIST="$INSTALL_DIR/ui-dist"
+if [ -f "$INSTALL_DIR/VERSION" ]; then
+  export REM_VERSION="\$(cat "$INSTALL_DIR/VERSION")"
+fi
+exec "$INSTALL_DIR/rem" "\$@"
+EOF
+chmod +x "$LAUNCHER_PATH"
+
+printf 'Installed rem:\n- install dir: %s\n- launcher: %s\n\n' "$INSTALL_DIR" "$LAUNCHER_PATH"
+printf 'Run: %s app\n' "$LAUNCHER_PATH"

--- a/scripts/install-macos.sh
+++ b/scripts/install-macos.sh
@@ -117,6 +117,9 @@ cp "$PACKAGE_DIR/rem" "$INSTALL_DIR/rem"
 cp "$PACKAGE_DIR/rem-api" "$INSTALL_DIR/rem-api"
 rm -rf "$INSTALL_DIR/ui-dist"
 cp -R "$PACKAGE_DIR/ui-dist" "$INSTALL_DIR/ui-dist"
+if [[ -f "$PACKAGE_DIR/VERSION" ]]; then
+  cp "$PACKAGE_DIR/VERSION" "$INSTALL_DIR/VERSION"
+fi
 if [[ -f "$PACKAGE_DIR/README.md" ]]; then
   cp "$PACKAGE_DIR/README.md" "$INSTALL_DIR/README.md"
 fi
@@ -128,6 +131,9 @@ cat >"$LAUNCHER_PATH" <<EOF
 #!/bin/sh
 export REM_API_BINARY="$INSTALL_DIR/rem-api"
 export REM_UI_DIST="$INSTALL_DIR/ui-dist"
+if [ -f "$INSTALL_DIR/VERSION" ]; then
+  export REM_VERSION="\$(cat "$INSTALL_DIR/VERSION")"
+fi
 exec "$INSTALL_DIR/rem" "\$@"
 EOF
 chmod +x "$LAUNCHER_PATH"

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -1,0 +1,81 @@
+$ErrorActionPreference = "Stop"
+
+param(
+  [string]$InstallDir = "",
+  [string]$BinDir = "",
+  [switch]$Local
+)
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+if ([string]::IsNullOrWhiteSpace($InstallDir)) {
+  if ($env:REM_INSTALL_DIR) {
+    $InstallDir = $env:REM_INSTALL_DIR
+  } else {
+    $InstallDir = Join-Path $env:LOCALAPPDATA "Programs\rem"
+  }
+}
+
+if ([string]::IsNullOrWhiteSpace($BinDir)) {
+  if ($env:REM_BIN_DIR) {
+    $BinDir = $env:REM_BIN_DIR
+  } else {
+    $BinDir = Join-Path $InstallDir "bin"
+  }
+}
+
+if ($Local.IsPresent) {
+  $userHome = if ($env:USERPROFILE) { $env:USERPROFILE } else { [Environment]::GetFolderPath("UserProfile") }
+  $InstallDir = Join-Path $env:LOCALAPPDATA "Programs\rem"
+  $BinDir = Join-Path $userHome ".local\bin"
+}
+
+$required = @(
+  "rem.exe",
+  "rem-api.exe",
+  "ui-dist\index.html"
+)
+foreach ($requiredPath in $required) {
+  $candidate = Join-Path $scriptDir $requiredPath
+  if (-not (Test-Path $candidate)) {
+    throw "Expected package file missing: $candidate"
+  }
+}
+
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+New-Item -ItemType Directory -Force -Path $BinDir | Out-Null
+
+Copy-Item -Path (Join-Path $scriptDir "rem.exe") -Destination (Join-Path $InstallDir "rem.exe") -Force
+Copy-Item -Path (Join-Path $scriptDir "rem-api.exe") -Destination (Join-Path $InstallDir "rem-api.exe") -Force
+
+$uiDestination = Join-Path $InstallDir "ui-dist"
+if (Test-Path $uiDestination) {
+  Remove-Item -Path $uiDestination -Recurse -Force
+}
+Copy-Item -Path (Join-Path $scriptDir "ui-dist") -Destination $uiDestination -Recurse -Force
+
+$versionPath = Join-Path $scriptDir "VERSION"
+if (Test-Path $versionPath) {
+  Copy-Item -Path $versionPath -Destination (Join-Path $InstallDir "VERSION") -Force
+}
+
+$readmePath = Join-Path $scriptDir "README.md"
+if (Test-Path $readmePath) {
+  Copy-Item -Path $readmePath -Destination (Join-Path $InstallDir "README.md") -Force
+}
+
+$launcherPath = Join-Path $BinDir "rem.cmd"
+$launcher = @"
+@echo off
+set "REM_API_BINARY=$InstallDir\rem-api.exe"
+set "REM_UI_DIST=$InstallDir\ui-dist"
+if exist "$InstallDir\VERSION" set /p REM_VERSION=<"$InstallDir\VERSION"
+"$InstallDir\rem.exe" %*
+"@
+Set-Content -Path $launcherPath -Value $launcher -Encoding Ascii
+
+Write-Host "Installed rem:"
+Write-Host "- install dir: $InstallDir"
+Write-Host "- launcher: $launcherPath"
+Write-Host ""
+Write-Host "Run: $launcherPath app"

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+SEMVER_PATTERN='^[0-9]+\.[0-9]+\.[0-9]+$'
+VERSION="${1:-$(bun run scripts/semver-version.ts)}"
+if [[ ! "$VERSION" =~ $SEMVER_PATTERN ]]; then
+  echo "Version must be semantic (MAJOR.MINOR.PATCH), got: $VERSION" >&2
+  exit 1
+fi
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64 | amd64)
+    ARCH_LABEL="x64"
+    ;;
+  aarch64 | arm64)
+    ARCH_LABEL="arm64"
+    ;;
+  *)
+    echo "Unsupported Linux architecture: $ARCH" >&2
+    exit 1
+    ;;
+esac
+
+DIST_ROOT="$ROOT_DIR/dist/linux"
+PACKAGE_NAME="rem-${VERSION}-linux-${ARCH_LABEL}"
+PACKAGE_DIR="$DIST_ROOT/$PACKAGE_NAME"
+ARCHIVE_PATH="$DIST_ROOT/${PACKAGE_NAME}.tar.gz"
+CHECKSUM_PATH="$ARCHIVE_PATH.sha256"
+
+rm -rf "$PACKAGE_DIR"
+mkdir -p "$PACKAGE_DIR"
+
+bun run --cwd apps/ui build
+
+bun build --compile --outfile "$PACKAGE_DIR/rem" apps/cli/src/index.ts
+bun build --compile --outfile "$PACKAGE_DIR/rem-api" apps/api/src/index.ts
+
+cp -R apps/ui/dist "$PACKAGE_DIR/ui-dist"
+cp README.md "$PACKAGE_DIR/README.md"
+cp scripts/install-linux.sh "$PACKAGE_DIR/install.sh"
+printf '%s\n' "$VERSION" >"$PACKAGE_DIR/VERSION"
+chmod +x "$PACKAGE_DIR/install.sh"
+
+"$PACKAGE_DIR/rem" --help >/dev/null
+
+API_LOG="$PACKAGE_DIR/rem-api-smoke.log"
+REM_API_PORT=0 REM_UI_DIST="$PACKAGE_DIR/ui-dist" "$PACKAGE_DIR/rem-api" >"$API_LOG" 2>&1 &
+API_PID=$!
+
+sleep 2
+if ! kill -0 "$API_PID" 2>/dev/null; then
+  cat "$API_LOG" >&2 || true
+  wait "$API_PID" || true
+  echo "rem-api smoke test failed to start" >&2
+  exit 1
+fi
+
+kill "$API_PID" 2>/dev/null || true
+wait "$API_PID" 2>/dev/null || true
+rm -f "$API_LOG"
+
+rm -f "$ARCHIVE_PATH" "$CHECKSUM_PATH"
+(
+  cd "$DIST_ROOT"
+  tar -czf "$(basename "$ARCHIVE_PATH")" "$PACKAGE_NAME"
+)
+
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256sum "$ARCHIVE_PATH" >"$CHECKSUM_PATH"
+else
+  shasum -a 256 "$ARCHIVE_PATH" >"$CHECKSUM_PATH"
+fi
+
+printf 'Created package:\n- %s\n- %s\n' "$ARCHIVE_PATH" "$CHECKSUM_PATH"

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -43,6 +43,7 @@ bun build --compile --outfile "$PACKAGE_DIR/rem-api" apps/api/src/index.ts
 cp -R apps/ui/dist "$PACKAGE_DIR/ui-dist"
 cp README.md "$PACKAGE_DIR/README.md"
 cp scripts/install-macos.sh "$PACKAGE_DIR/install.sh"
+printf '%s\n' "$VERSION" >"$PACKAGE_DIR/VERSION"
 chmod +x "$PACKAGE_DIR/install.sh"
 
 "$PACKAGE_DIR/rem" --help >/dev/null

--- a/scripts/package-windows.ps1
+++ b/scripts/package-windows.ps1
@@ -1,0 +1,84 @@
+$ErrorActionPreference = "Stop"
+
+param(
+  [string]$Version = ""
+)
+
+$rootDir = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+Set-Location $rootDir
+
+if ([string]::IsNullOrWhiteSpace($Version)) {
+  $Version = (bun run scripts/semver-version.ts).Trim()
+}
+if ($Version -notmatch "^\d+\.\d+\.\d+$") {
+  throw "Version must be semantic (MAJOR.MINOR.PATCH), got: $Version"
+}
+
+$archRaw = "$env:PROCESSOR_ARCHITECTURE".ToLowerInvariant()
+switch ($archRaw) {
+  "amd64" { $archLabel = "x64" }
+  "x86_64" { $archLabel = "x64" }
+  "arm64" { $archLabel = "arm64" }
+  default { throw "Unsupported Windows architecture: $archRaw" }
+}
+
+$distRoot = Join-Path $rootDir "dist\windows"
+$packageName = "rem-$Version-windows-$archLabel"
+$packageDir = Join-Path $distRoot $packageName
+$archivePath = Join-Path $distRoot "$packageName.zip"
+$checksumPath = "$archivePath.sha256"
+
+if (Test-Path $packageDir) {
+  Remove-Item -Path $packageDir -Recurse -Force
+}
+New-Item -ItemType Directory -Path $packageDir -Force | Out-Null
+
+bun run --cwd apps/ui build
+
+bun build --compile --outfile "$packageDir\rem.exe" apps/cli/src/index.ts
+bun build --compile --outfile "$packageDir\rem-api.exe" apps/api/src/index.ts
+
+Copy-Item -Path "apps/ui/dist" -Destination (Join-Path $packageDir "ui-dist") -Recurse -Force
+Copy-Item -Path "README.md" -Destination (Join-Path $packageDir "README.md") -Force
+Copy-Item -Path "scripts/install-windows.ps1" -Destination (Join-Path $packageDir "install.ps1") -Force
+Set-Content -Path (Join-Path $packageDir "VERSION") -Value "$Version" -NoNewline -Encoding Ascii
+
+& (Join-Path $packageDir "rem.exe") --help | Out-Null
+
+$apiLog = Join-Path $packageDir "rem-api-smoke.log"
+$apiEnvironment = @{
+  REM_API_PORT = "0"
+  REM_UI_DIST = (Join-Path $packageDir "ui-dist")
+}
+$apiProcess = Start-Process -FilePath (Join-Path $packageDir "rem-api.exe") -RedirectStandardOutput $apiLog -RedirectStandardError $apiLog -PassThru -WindowStyle Hidden -Environment $apiEnvironment
+
+Start-Sleep -Seconds 2
+if ($apiProcess.HasExited) {
+  if (Test-Path $apiLog) {
+    Get-Content $apiLog | Write-Error
+  }
+  throw "rem-api smoke test failed to start"
+}
+
+Stop-Process -Id $apiProcess.Id -Force
+Start-Sleep -Milliseconds 250
+if (Test-Path $apiLog) {
+  Remove-Item -Path $apiLog -Force
+}
+
+if (Test-Path $archivePath) {
+  Remove-Item -Path $archivePath -Force
+}
+if (Test-Path $checksumPath) {
+  Remove-Item -Path $checksumPath -Force
+}
+
+Compress-Archive -Path $packageDir -DestinationPath $archivePath -CompressionLevel Optimal
+
+$digest = (Get-FileHash -Algorithm SHA256 -Path $archivePath).Hash.ToLowerInvariant()
+$archiveLeaf = Split-Path -Path $archivePath -Leaf
+Set-Content -Path $checksumPath -Value "$digest  $archiveLeaf" -Encoding Ascii
+
+Write-Host "Created package:"
+Write-Host "- $archivePath"
+Write-Host "- $checksumPath"


### PR DESCRIPTION
## Summary
- add `rem update` support for in-place upgrades from GitHub releases
- support `darwin`, `linux`, and `win32` artifacts with checksum validation and platform installers
- add updater flow/error-path coverage and CLI JSON contract tests for invalid update arch

## Validation
- bun run lint
- bun run typecheck
- bun test apps/cli/src/update.test.ts apps/cli/src/index.test.ts
- bun run test

Refs #35