### PR TITLE
Allow editor title to expand for long note names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ node_modules/
 .DS_Store
 dist/
 coverage/
+.playwright-cli/
+output/playwright/
 *.log
 *.tsbuildinfo
 bun.lock

--- a/apps/ui/src/styles.css
+++ b/apps/ui/src/styles.css
@@ -266,7 +266,6 @@ body {
   letter-spacing: 0.01em;
   line-height: 1.2;
   color: var(--text);
-  overflow-wrap: anywhere;
 }
 
 .panel-meta-line {
@@ -413,8 +412,9 @@ body {
   font-size: 0.89rem;
   font-weight: 500;
   line-height: 1.25;
-  white-space: normal;
-  overflow-wrap: anywhere;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .note-tree-copy span {
@@ -463,14 +463,15 @@ body {
 }
 
 .topbar-meta {
+  flex: 1 1 auto;
   min-width: 0;
   display: grid;
   gap: 0.34rem;
 }
 
 .topbar-title-input {
-  min-width: min(40rem, 100%);
-  width: min(40rem, 100%);
+  min-width: 0;
+  width: 100%;
   font-size: 1.06rem;
   font-weight: 500;
   color: var(--text);
@@ -1136,9 +1137,5 @@ body {
 
   .canvas {
     padding: 1rem 0.95rem 1.8rem;
-  }
-
-  .topbar-title-input {
-    width: min(30rem, 100%);
   }
 }

--- a/apps/ui/src/styles.css
+++ b/apps/ui/src/styles.css
@@ -266,6 +266,7 @@ body {
   letter-spacing: 0.01em;
   line-height: 1.2;
   color: var(--text);
+  overflow-wrap: anywhere;
 }
 
 .panel-meta-line {
@@ -412,9 +413,8 @@ body {
   font-size: 0.89rem;
   font-weight: 500;
   line-height: 1.25;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 
 .note-tree-copy span {

--- a/apps/ui/src/styles.test.ts
+++ b/apps/ui/src/styles.test.ts
@@ -14,4 +14,10 @@ describe("command palette styles", () => {
     expect(stylesCss).toMatch(/\.command-palette\s*{[^}]*border:\s*1px\s+solid\s+color-mix\(/s);
     expect(stylesCss).not.toMatch(/--border:/);
   });
+
+  test("allows long sidebar note titles to wrap instead of truncating with ellipsis", () => {
+    expect(stylesCss).toMatch(/\.note-tree-copy strong\s*{[^}]*white-space:\s*normal;/s);
+    expect(stylesCss).toMatch(/\.note-tree-copy strong\s*{[^}]*overflow-wrap:\s*anywhere;/s);
+    expect(stylesCss).not.toMatch(/\.note-tree-copy strong\s*{[^}]*text-overflow:\s*ellipsis;/s);
+  });
 });

--- a/apps/ui/src/styles.test.ts
+++ b/apps/ui/src/styles.test.ts
@@ -15,9 +15,12 @@ describe("command palette styles", () => {
     expect(stylesCss).not.toMatch(/--border:/);
   });
 
-  test("allows long sidebar note titles to wrap instead of truncating with ellipsis", () => {
-    expect(stylesCss).toMatch(/\.note-tree-copy strong\s*{[^}]*white-space:\s*normal;/s);
-    expect(stylesCss).toMatch(/\.note-tree-copy strong\s*{[^}]*overflow-wrap:\s*anywhere;/s);
-    expect(stylesCss).not.toMatch(/\.note-tree-copy strong\s*{[^}]*text-overflow:\s*ellipsis;/s);
+  test("lets the editor title field expand horizontally instead of capping it at 40rem", () => {
+    expect(stylesCss).toMatch(/\.topbar-meta\s*{[^}]*flex:\s*1\s+1\s+auto;/s);
+    expect(stylesCss).toMatch(/\.topbar-title-input\s*{[^}]*width:\s*100%;/s);
+    expect(stylesCss).not.toMatch(/\.topbar-title-input\s*{[^}]*width:\s*min\(40rem,\s*100%\);/s);
+    expect(stylesCss).not.toMatch(
+      /\.topbar-title-input\s*{[^}]*min-width:\s*min\(40rem,\s*100%\);/s,
+    );
   });
 });

--- a/docs/design.md
+++ b/docs/design.md
@@ -2,7 +2,7 @@
 
 **Document status:** Draft (v1)  
 **Owner:** Erik  
-**Last updated:** 2026-02-22  
+**Last updated:** 2026-03-07  
 **Project:** rem
 
 ---
@@ -46,6 +46,7 @@ Responsibilities:
 - editor UX (Lexical)
 - wiki-link UX for linking/opening notes
 - note list/sidebar, settings page, and command palette actions (`Today`, `Add Note`)
+- implemented: sidebar note titles wrap across multiple lines so long titles remain readable in the note tree
 - daily-note startup/open flow via API
 - authentication is local-only (no multi-user in v1)
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -46,7 +46,7 @@ Responsibilities:
 - editor UX (Lexical)
 - wiki-link UX for linking/opening notes
 - note list/sidebar, settings page, and command palette actions (`Today`, `Add Note`)
-- implemented: sidebar note titles wrap across multiple lines so long titles remain readable in the note tree
+- implemented: editor title field expands across the top bar so long note titles stay visible on one line instead of being capped at a fixed width
 - daily-note startup/open flow via API
 - authentication is local-only (no multi-user in v1)
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,5 +1,5 @@
 # rem Operator Runbook
-**Last updated:** 2026-02-22
+**Last updated:** 2026-03-07
 
 This runbook covers local operation of rem across notes, proposals, plugins, scheduler runtime, entities, and rebuild workflows.
 
@@ -23,6 +23,9 @@ bun run --cwd apps/ui dev
 ```
 
 Default API: `http://127.0.0.1:8787`
+
+UI smoke check:
+- Open the UI, create a note with a long multi-word title, and confirm the sidebar note tree wraps the full title onto multiple lines instead of truncating it with ellipsis.
 
 ## Binary upgrade workflow (CLI)
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -25,7 +25,7 @@ bun run --cwd apps/ui dev
 Default API: `http://127.0.0.1:8787`
 
 UI smoke check:
-- Open the UI, create a note with a long multi-word title, and confirm the sidebar note tree wraps the full title onto multiple lines instead of truncating it with ellipsis.
+- Open the UI, create a note with a long single-line title, and confirm the editor title field expands horizontally across the top bar so the full title remains visible without wrapping.
 
 ## Binary upgrade workflow (CLI)
 


### PR DESCRIPTION
Summary
- let the topbar meta container flex and allow the title input to span the full width so long note titles stay on one line
- add Playwright output directories to `.gitignore`
- update documentation to note the new layout behavior and provide a manual smoke check reminder

Testing
- Not run (not requested)