### PR TITLE
Add note search results to command palette

### DIFF
--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -28,15 +28,18 @@ import {
   KEY_TAB_COMMAND,
   type LexicalNode,
 } from "lexical";
-import { CalendarDays, Menu, Plus, RefreshCw, Search, Settings } from "lucide-react";
+import { CalendarDays, FileText, Menu, Plus, RefreshCw, Search, Settings } from "lucide-react";
 
 import { WikiLinksPlugin } from "./WikiLinkPlugin";
 import {
+  type CommandPaletteMatch,
+  type CommandPaletteNoteResult,
+  buildCommandPaletteSections,
+  flattenCommandPaletteSections,
   getNextCommandIndex,
   getPreviousCommandIndex,
   isNextCommandShortcut,
   isPreviousCommandShortcut,
-  matchesCommandQuery,
 } from "./command-palette";
 import { Button } from "./components/ui/button";
 import { Input } from "./components/ui/input";
@@ -53,6 +56,8 @@ import type { CanonicalNoteRecord } from "./proposals";
 
 const API_BASE_URL = import.meta.env.VITE_REM_API_BASE_URL ?? "http://127.0.0.1:8787";
 const AUTOSAVE_DELAY_MS = 1200;
+const COMMAND_NOTE_SEARCH_LIMIT = 8;
+const COMMAND_NOTE_SEARCH_DEBOUNCE_MS = 180;
 const EDITOR_THEME = {
   text: {
     strikethrough: "lexical-text-strikethrough",
@@ -383,6 +388,11 @@ export function App() {
   const [isCommandPaletteOpen, setIsCommandPaletteOpen] = useState(false);
   const [commandQuery, setCommandQuery] = useState("");
   const [activeCommandIndex, setActiveCommandIndex] = useState(0);
+  const [commandNoteResults, setCommandNoteResults] = useState<CommandPaletteNoteResult[]>([]);
+  const [commandNoteSearchState, setCommandNoteSearchState] = useState<SaveState>({
+    kind: "idle",
+    message: "Type to search notes.",
+  });
   const [commandState, setCommandState] = useState<SaveState>({
     kind: "idle",
     message: "Ready.",
@@ -434,6 +444,25 @@ export function App() {
         ),
     );
   }, [notes, notesQuery]);
+
+  const commandPaletteSections = useMemo(
+    () => buildCommandPaletteSections(commandQuery, commandNoteResults),
+    [commandNoteResults, commandQuery],
+  );
+  const commandPaletteItems = useMemo(
+    () => flattenCommandPaletteSections(commandPaletteSections),
+    [commandPaletteSections],
+  );
+  const commandPaletteSectionsWithIndices = useMemo(() => {
+    let nextIndex = 0;
+    return commandPaletteSections.map((section) => ({
+      ...section,
+      items: section.items.map((item) => ({
+        item,
+        index: nextIndex++,
+      })),
+    }));
+  }, [commandPaletteSections]);
 
   const saveIndicator = useMemo<SaveIndicator>(() => {
     if (saveState.kind === "error") {
@@ -658,6 +687,11 @@ export function App() {
     }
 
     setCommandQuery("");
+    setCommandNoteResults([]);
+    setCommandNoteSearchState({
+      kind: "idle",
+      message: "Type to search notes.",
+    });
     setCommandState({
       kind: "idle",
       message: "Ready.",
@@ -821,6 +855,72 @@ export function App() {
       });
     }
   }, []);
+
+  useEffect(() => {
+    if (!isCommandPaletteOpen) {
+      return;
+    }
+
+    const normalizedQuery = commandQuery.trim();
+    if (!normalizedQuery) {
+      setCommandNoteResults([]);
+      setCommandNoteSearchState({
+        kind: "idle",
+        message: "Type to search notes.",
+      });
+      return;
+    }
+
+    const controller = new AbortController();
+    setCommandNoteResults([]);
+    setCommandNoteSearchState({
+      kind: "saving",
+      message: "Searching notes...",
+    });
+    const timer = setTimeout(() => {
+      void (async () => {
+        try {
+          const params = new URLSearchParams({
+            q: normalizedQuery,
+            limit: COMMAND_NOTE_SEARCH_LIMIT.toString(),
+          });
+          const response = await fetch(`${API_BASE_URL}/search?${params.toString()}`, {
+            signal: controller.signal,
+          });
+
+          if (!response.ok) {
+            throw new Error(`Failed searching notes (${response.status})`);
+          }
+
+          const payload = (await response.json()) as CommandPaletteNoteResult[];
+          if (controller.signal.aborted) {
+            return;
+          }
+
+          setCommandNoteResults(payload);
+          setCommandNoteSearchState({
+            kind: "success",
+            message: payload.length === 0 ? "No notes found." : `Found ${payload.length} notes.`,
+          });
+        } catch (error) {
+          if (controller.signal.aborted) {
+            return;
+          }
+
+          setCommandNoteResults([]);
+          setCommandNoteSearchState({
+            kind: "error",
+            message: error instanceof Error ? error.message : "Failed searching notes.",
+          });
+        }
+      })();
+    }, COMMAND_NOTE_SEARCH_DEBOUNCE_MS);
+
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [commandQuery, isCommandPaletteOpen]);
 
   const createWikiLinkedNote = useCallback(
     async (rawTitle: string): Promise<NoteSummary | null> => {
@@ -986,73 +1086,64 @@ export function App() {
     [closeCommandPalette, openNote, refreshNotes],
   );
 
-  const isTodayCommandVisible = matchesCommandQuery(commandQuery, [
-    "today",
-    "open today's daily note",
-  ]);
-  const isAddNoteCommandVisible = matchesCommandQuery(commandQuery, [
-    "add note",
-    "create a new note",
-    "new note",
-  ]);
+  const selectCommandPaletteItem = useCallback(
+    (item: CommandPaletteMatch): void => {
+      if (item.kind === "command") {
+        if (item.id === "today") {
+          void openTodayNote("command");
+          return;
+        }
 
-  const commandItems: Array<{
-    id: "today" | "add-note";
-    label: string;
-    icon: typeof CalendarDays;
-    onSelect: () => void;
-  }> = [];
-  if (isTodayCommandVisible) {
-    commandItems.push({
-      id: "today",
-      label: "Today",
-      icon: CalendarDays,
-      onSelect: () => {
-        void openTodayNote("command");
-      },
-    });
-  }
-  if (isAddNoteCommandVisible) {
-    commandItems.push({
-      id: "add-note",
-      label: "Add Note",
-      icon: Plus,
-      onSelect: () => {
         void createNewNote();
-      },
-    });
-  }
+        return;
+      }
+
+      closeCommandPalette();
+      void openNote(item.noteId);
+    },
+    [closeCommandPalette, createNewNote, openNote, openTodayNote],
+  );
 
   useEffect(() => {
     if (!isCommandPaletteOpen) {
       return;
     }
 
-    if (commandItems.length === 0) {
+    if (commandPaletteItems.length === 0) {
       if (activeCommandIndex !== 0) {
         setActiveCommandIndex(0);
       }
       return;
     }
 
-    if (activeCommandIndex >= commandItems.length) {
-      setActiveCommandIndex(commandItems.length - 1);
+    if (activeCommandIndex >= commandPaletteItems.length) {
+      setActiveCommandIndex(commandPaletteItems.length - 1);
     }
-  }, [activeCommandIndex, isCommandPaletteOpen]);
+  }, [activeCommandIndex, commandPaletteItems.length, isCommandPaletteOpen]);
 
   const selectedCommandIndex =
-    commandItems.length === 0 ? 0 : Math.min(activeCommandIndex, commandItems.length - 1);
-  const selectedCommand = commandItems[selectedCommandIndex] ?? null;
+    commandPaletteItems.length === 0
+      ? 0
+      : Math.min(activeCommandIndex, commandPaletteItems.length - 1);
+  const selectedCommand = commandPaletteItems[selectedCommandIndex] ?? null;
+  const displayedCommandPaletteState =
+    commandState.kind !== "idle" ||
+    commandNoteSearchState.kind === "saving" ||
+    commandNoteSearchState.kind === "error"
+      ? commandState.kind !== "idle"
+        ? commandState
+        : commandNoteSearchState
+      : commandState;
 
   useEffect(() => {
-    if (!isCommandPaletteOpen || commandItems.length === 0) {
+    if (!isCommandPaletteOpen || commandPaletteItems.length === 0) {
       return;
     }
 
     commandItemRefs.current[selectedCommandIndex]?.scrollIntoView({
       block: "nearest",
     });
-  }, [isCommandPaletteOpen, selectedCommandIndex]);
+  }, [commandPaletteItems.length, isCommandPaletteOpen, selectedCommandIndex]);
 
   useEffect(() => {
     if (hasOpenedInitialDailyNoteRef.current) {
@@ -1436,25 +1527,25 @@ export function App() {
                 ref={commandSearchInputRef}
                 type="text"
                 className="command-palette-search-input"
-                placeholder="Search commands"
+                placeholder="Search commands or notes"
                 value={commandQuery}
                 onChange={(event) => {
                   setCommandQuery(event.currentTarget.value);
                   setActiveCommandIndex(0);
                 }}
                 onKeyDown={(event) => {
-                  if (isNextCommandShortcut(event) && commandItems.length > 0) {
+                  if (isNextCommandShortcut(event) && commandPaletteItems.length > 0) {
                     event.preventDefault();
                     setActiveCommandIndex((current) =>
-                      getNextCommandIndex(current, commandItems.length),
+                      getNextCommandIndex(current, commandPaletteItems.length),
                     );
                     return;
                   }
 
-                  if (isPreviousCommandShortcut(event) && commandItems.length > 0) {
+                  if (isPreviousCommandShortcut(event) && commandPaletteItems.length > 0) {
                     event.preventDefault();
                     setActiveCommandIndex((current) =>
-                      getPreviousCommandIndex(current, commandItems.length),
+                      getPreviousCommandIndex(current, commandPaletteItems.length),
                     );
                     return;
                   }
@@ -1465,56 +1556,84 @@ export function App() {
                     commandState.kind !== "saving"
                   ) {
                     event.preventDefault();
-                    selectedCommand.onSelect();
+                    selectCommandPaletteItem(selectedCommand);
                   }
                 }}
-                aria-label="Search commands"
+                aria-label="Search commands or notes"
               />
             </div>
-            <section className="command-palette-group" aria-label="Suggested commands">
-              <p className="command-palette-group-label">Suggested</p>
-              <ul className="command-palette-list" aria-label="Command list">
-                {commandItems.length > 0 ? (
-                  commandItems.map((command, index) => {
-                    const CommandIcon = command.icon;
-                    const isActive = index === selectedCommandIndex;
-                    return (
-                      <li key={command.id}>
-                        <button
-                          type="button"
-                          ref={(element) => {
-                            commandItemRefs.current[index] = element;
-                          }}
-                          className={
-                            isActive
-                              ? "command-palette-item command-palette-item-active"
-                              : "command-palette-item"
-                          }
-                          onClick={command.onSelect}
-                          disabled={commandState.kind === "saving"}
-                        >
-                          <span className="command-palette-item-main">
-                            <CommandIcon className="ui-icon" aria-hidden="true" />
-                            <span>{command.label}</span>
-                          </span>
-                          {isActive ? <kbd className="command-palette-shortcut">Enter</kbd> : null}
-                        </button>
-                      </li>
-                    );
-                  })
-                ) : (
-                  <li>
-                    <p className="command-palette-empty">No matching commands.</p>
-                  </li>
-                )}
-              </ul>
-            </section>
-            {commandState.kind === "idle" ? null : (
+            {commandPaletteSectionsWithIndices.length > 0 ? (
+              commandPaletteSectionsWithIndices.map((section) => (
+                <section
+                  key={section.id}
+                  className="command-palette-group"
+                  aria-label={`${section.label} results`}
+                >
+                  <p className="command-palette-group-label">{section.label}</p>
+                  <ul className="command-palette-list" aria-label={`${section.label} list`}>
+                    {section.items.map(({ item, index }) => {
+                      const isActive = index === selectedCommandIndex;
+                      return (
+                        <li key={item.id}>
+                          <button
+                            type="button"
+                            ref={(element) => {
+                              commandItemRefs.current[index] = element;
+                            }}
+                            className={
+                              isActive
+                                ? "command-palette-item command-palette-item-active"
+                                : "command-palette-item"
+                            }
+                            onClick={() => {
+                              selectCommandPaletteItem(item);
+                            }}
+                            disabled={commandState.kind === "saving"}
+                          >
+                            {item.kind === "command" ? (
+                              <>
+                                <span className="command-palette-item-main">
+                                  {item.id === "today" ? (
+                                    <CalendarDays className="ui-icon" aria-hidden="true" />
+                                  ) : (
+                                    <Plus className="ui-icon" aria-hidden="true" />
+                                  )}
+                                  <span>{item.label}</span>
+                                </span>
+                                <span className="command-palette-shortcut">{item.shortcut}</span>
+                              </>
+                            ) : (
+                              <>
+                                <span className="command-palette-item-copy">
+                                  <span className="command-palette-item-main">
+                                    <FileText className="ui-icon" aria-hidden="true" />
+                                    <span>{item.title}</span>
+                                  </span>
+                                  <span className="command-palette-item-secondary">
+                                    {item.snippet}
+                                  </span>
+                                </span>
+                                <span className="command-palette-meta">
+                                  {formatModifiedAt(item.updatedAt)}
+                                </span>
+                              </>
+                            )}
+                          </button>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </section>
+              ))
+            ) : commandNoteSearchState.kind === "saving" ? null : (
+              <p className="command-palette-empty">No matching commands or notes.</p>
+            )}
+            {displayedCommandPaletteState.kind === "idle" ? null : (
               <p
-                className={`command-palette-status command-palette-status-${commandState.kind}`}
+                className={`command-palette-status command-palette-status-${displayedCommandPaletteState.kind}`}
                 aria-live="polite"
               >
-                {commandState.message}
+                {displayedCommandPaletteState.message}
               </p>
             )}
           </dialog>

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -142,14 +142,14 @@ type StoreRootConfigResponse = {
   source: "runtime" | "env" | "config" | "default";
 };
 
-function formatSavedAt(iso: string): string {
+export function formatSavedAt(iso: string): string {
   return new Date(iso).toLocaleTimeString(undefined, {
     hour: "2-digit",
     minute: "2-digit",
   });
 }
 
-function formatModifiedAt(iso: string): string {
+export function formatModifiedAt(iso: string): string {
   return new Date(iso).toLocaleString(undefined, {
     month: "short",
     day: "numeric",
@@ -158,11 +158,11 @@ function formatModifiedAt(iso: string): string {
   });
 }
 
-function isThemePreference(value: string): value is ThemePreference {
+export function isThemePreference(value: string): value is ThemePreference {
   return value === "dark" || value === "light" || value === "system";
 }
 
-function formatStoreRootMessage(config: StoreRootConfigResponse): string {
+export function formatStoreRootMessage(config: StoreRootConfigResponse): string {
   if (config.source === "runtime") {
     return `Using ${config.effectiveStoreRoot} (changed in this app session).`;
   }
@@ -178,7 +178,7 @@ function formatStoreRootMessage(config: StoreRootConfigResponse): string {
   return `Using default store root ${config.defaultStoreRoot}.`;
 }
 
-function createNoteSavePayload(
+export function createNoteSavePayload(
   rawTitle: string,
   lexicalState: LexicalStateLike,
   tags: string[],

--- a/apps/ui/src/app.test.tsx
+++ b/apps/ui/src/app.test.tsx
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { renderToString } from "react-dom/server";
 
-import { App } from "./App";
+import { App, createNoteSavePayload, formatStoreRootMessage, isThemePreference } from "./App";
+import { plainTextToLexicalState } from "./lexical";
 
 describe("App", () => {
   test("renders flat shell with push sidebar and settings entry", () => {
@@ -14,5 +15,74 @@ describe("App", () => {
     expect(html).toContain("Search notes");
     expect(html).toContain("Lexical editor loads in the browser.");
     expect(html).toContain("Unsaved");
+  });
+
+  test("formats store-root messages for each config source", () => {
+    expect(
+      formatStoreRootMessage({
+        schemaVersion: "v1",
+        configPath: "/tmp/rem/config.json",
+        defaultStoreRoot: "/tmp/rem-default",
+        configuredStoreRoot: null,
+        effectiveStoreRoot: "/tmp/runtime",
+        source: "runtime",
+      }),
+    ).toBe("Using /tmp/runtime (changed in this app session).");
+    expect(
+      formatStoreRootMessage({
+        schemaVersion: "v1",
+        configPath: "/tmp/rem/config.json",
+        defaultStoreRoot: "/tmp/rem-default",
+        configuredStoreRoot: null,
+        effectiveStoreRoot: "/tmp/env",
+        source: "env",
+      }),
+    ).toBe("Using /tmp/env from REM_STORE_ROOT.");
+    expect(
+      formatStoreRootMessage({
+        schemaVersion: "v1",
+        configPath: "/tmp/rem/config.json",
+        defaultStoreRoot: "/tmp/rem-default",
+        configuredStoreRoot: "/tmp/config",
+        effectiveStoreRoot: "/tmp/config",
+        source: "config",
+      }),
+    ).toBe("Using /tmp/config from /tmp/rem/config.json.");
+    expect(
+      formatStoreRootMessage({
+        schemaVersion: "v1",
+        configPath: "/tmp/rem/config.json",
+        defaultStoreRoot: "/tmp/rem-default",
+        configuredStoreRoot: null,
+        effectiveStoreRoot: "/tmp/rem-default",
+        source: "default",
+      }),
+    ).toBe("Using default store root /tmp/rem-default.");
+  });
+
+  test("builds note save payloads only when title or body is present", () => {
+    expect(createNoteSavePayload("   ", plainTextToLexicalState(""), [])).toBeNull();
+
+    expect(createNoteSavePayload("   ", plainTextToLexicalState("Body"), ["ops"])).toEqual({
+      body: {
+        title: "Untitled Note",
+        noteType: "note",
+        lexicalState: plainTextToLexicalState("Body"),
+        tags: ["ops"],
+      },
+      key: JSON.stringify({
+        title: "Untitled Note",
+        noteType: "note",
+        lexicalState: plainTextToLexicalState("Body"),
+        tags: ["ops"],
+      }),
+    });
+  });
+
+  test("recognizes valid theme preferences", () => {
+    expect(isThemePreference("dark")).toBeTrue();
+    expect(isThemePreference("light")).toBeTrue();
+    expect(isThemePreference("system")).toBeTrue();
+    expect(isThemePreference("sepia")).toBeFalse();
   });
 });

--- a/apps/ui/src/command-palette.test.ts
+++ b/apps/ui/src/command-palette.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  buildCommandPaletteSections,
+  flattenCommandPaletteSections,
+  formatCommandPaletteNoteSnippet,
   getNextCommandIndex,
   getPreviousCommandIndex,
   isNextCommandShortcut,
@@ -21,6 +24,74 @@ describe("command palette query matching", () => {
 
   test("returns false when aliases do not match", () => {
     expect(matchesCommandQuery("deploy", ["today", "add note"])).toBe(false);
+  });
+
+  test("builds command and note sections for the palette", () => {
+    expect(
+      buildCommandPaletteSections("", [
+        {
+          id: "note-1",
+          title: "Release plan",
+          updatedAt: "2026-03-07T10:00:00.000Z",
+          snippet: "ignored when query is empty",
+        },
+      ]),
+    ).toEqual([
+      {
+        id: "suggested",
+        label: "Suggested",
+        items: [
+          { kind: "command", id: "today", label: "Today", shortcut: "↵" },
+          { kind: "command", id: "add-note", label: "Add Note", shortcut: "↵" },
+        ],
+      },
+    ]);
+
+    expect(
+      buildCommandPaletteSections("release", [
+        {
+          id: "note-1",
+          title: "Release plan",
+          updatedAt: "2026-03-07T10:00:00.000Z",
+          snippet: "Ship the [release] checklist",
+        },
+      ]),
+    ).toEqual([
+      {
+        id: "notes",
+        label: "Notes",
+        items: [
+          {
+            kind: "note",
+            id: "note:note-1",
+            noteId: "note-1",
+            title: "Release plan",
+            updatedAt: "2026-03-07T10:00:00.000Z",
+            snippet: "Ship the release checklist",
+          },
+        ],
+      },
+    ]);
+  });
+
+  test("flattens grouped palette items in render order", () => {
+    const items = flattenCommandPaletteSections(
+      buildCommandPaletteSections("note", [
+        {
+          id: "note-1",
+          title: "Note search",
+          updatedAt: "2026-03-07T10:00:00.000Z",
+          snippet: "Search [note] content",
+        },
+      ]),
+    );
+
+    expect(items.map((item) => item.id)).toEqual(["today", "add-note", "note:note-1"]);
+  });
+
+  test("normalizes note snippets for display", () => {
+    expect(formatCommandPaletteNoteSnippet("Review [deploy] notes")).toBe("Review deploy notes");
+    expect(formatCommandPaletteNoteSnippet("   ")).toBe("Open note");
   });
 
   test("detects next and previous navigation shortcuts", () => {

--- a/apps/ui/src/command-palette.ts
+++ b/apps/ui/src/command-palette.ts
@@ -7,6 +7,103 @@ export function matchesCommandQuery(query: string, aliases: readonly string[]): 
   return aliases.some((alias) => alias.toLowerCase().includes(normalizedQuery));
 }
 
+const COMMAND_DEFINITIONS = [
+  {
+    id: "today",
+    label: "Today",
+    aliases: ["today", "open today's daily note"],
+    shortcut: "↵",
+  },
+  {
+    id: "add-note",
+    label: "Add Note",
+    aliases: ["add note", "create a new note", "new note"],
+    shortcut: "↵",
+  },
+] as const;
+
+export type CommandPaletteCommandId = (typeof COMMAND_DEFINITIONS)[number]["id"];
+
+export type CommandPaletteNoteResult = {
+  id: string;
+  title: string;
+  updatedAt: string;
+  snippet: string;
+};
+
+export type CommandPaletteMatch =
+  | {
+      kind: "command";
+      id: CommandPaletteCommandId;
+      label: string;
+      shortcut: string;
+    }
+  | {
+      kind: "note";
+      id: `note:${string}`;
+      noteId: string;
+      title: string;
+      updatedAt: string;
+      snippet: string;
+    };
+
+export type CommandPaletteSection = {
+  id: "suggested" | "notes";
+  label: string;
+  items: CommandPaletteMatch[];
+};
+
+export function formatCommandPaletteNoteSnippet(snippet: string): string {
+  const normalized = snippet.replaceAll("[", "").replaceAll("]", "").replace(/\s+/g, " ").trim();
+  return normalized || "Open note";
+}
+
+export function buildCommandPaletteSections(
+  query: string,
+  noteResults: readonly CommandPaletteNoteResult[],
+): CommandPaletteSection[] {
+  const sections: CommandPaletteSection[] = [];
+  const matchingCommands = COMMAND_DEFINITIONS.filter((command) =>
+    matchesCommandQuery(query, command.aliases),
+  ).map((command) => ({
+    kind: "command" as const,
+    id: command.id,
+    label: command.label,
+    shortcut: command.shortcut,
+  }));
+
+  if (matchingCommands.length > 0) {
+    sections.push({
+      id: "suggested",
+      label: "Suggested",
+      items: matchingCommands,
+    });
+  }
+
+  if (query.trim().length > 0 && noteResults.length > 0) {
+    sections.push({
+      id: "notes",
+      label: "Notes",
+      items: noteResults.map((note) => ({
+        kind: "note" as const,
+        id: `note:${note.id}`,
+        noteId: note.id,
+        title: note.title,
+        updatedAt: note.updatedAt,
+        snippet: formatCommandPaletteNoteSnippet(note.snippet),
+      })),
+    });
+  }
+
+  return sections;
+}
+
+export function flattenCommandPaletteSections(
+  sections: readonly CommandPaletteSection[],
+): CommandPaletteMatch[] {
+  return sections.flatMap((section) => section.items);
+}
+
 type CommandPaletteNavigationEvent = {
   key: string;
   ctrlKey: boolean;

--- a/apps/ui/src/styles.css
+++ b/apps/ui/src/styles.css
@@ -186,12 +186,35 @@ body {
   display: inline-flex;
   align-items: center;
   gap: 0.48rem;
+  min-width: 0;
 }
 
 .command-palette-item-main .ui-icon {
   width: 0.9rem;
   height: 0.9rem;
   color: var(--muted-strong);
+}
+
+.command-palette-item-main span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.command-palette-item-copy {
+  min-width: 0;
+  display: grid;
+  gap: 0.16rem;
+}
+
+.command-palette-item-secondary {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.78rem;
+  color: var(--muted);
 }
 
 .command-palette-shortcut {
@@ -203,6 +226,14 @@ body {
   font-size: 0.72rem;
   font-family: "IBM Plex Mono", "SF Mono", monospace;
   line-height: 1.28;
+}
+
+.command-palette-meta {
+  flex-shrink: 0;
+  font-size: 0.7rem;
+  color: var(--muted);
+  font-family: "IBM Plex Mono", "SF Mono", monospace;
+  white-space: nowrap;
 }
 
 .command-palette-empty {

--- a/docs/daily-notes-plugin-spec.md
+++ b/docs/daily-notes-plugin-spec.md
@@ -2,7 +2,7 @@
 
 **Document status:** Draft (implementation-ready)
 **Owner:** rem core/ui
-**Last updated:** 2026-02-13
+**Last updated:** 2026-03-07
 **Related docs:** `docs/plugin-runtime-spec.md`, `docs/data-contracts.md`, `docs/api-cli-reference.md`, `docs/runbook.md`
 
 ## 1) Scope and confirmed product decisions
@@ -12,7 +12,7 @@ This spec defines a new Daily Notes plugin capability that:
 1. Creates one daily note per local calendar day.
 2. Uses an English display title format exactly like `Monday Jan 15th 2026`.
 3. Opens today's daily note by default on app startup, creating it if missing.
-4. Adds a command palette `Today` command that opens today's note, creating it if missing.
+4. Keeps a command palette `Today` command that opens today's note, creating it if missing.
 5. Makes daily notes discoverable by:
    - full display title
    - date input formats:
@@ -30,16 +30,16 @@ Confirmed decisions from product:
 4. Default tag: include `daily`.
 5. Startup behavior: always open/create today's note.
 6. Plugin lifecycle: auto-bootstrap and enable by default.
-7. Command palette scope: only `Today` (no other commands in this feature).
+7. Command palette requirement for this feature: `Today` must remain available even as the shared palette adds other actions and note search/open results.
 
 ## 2) Why this needs careful design
 
 Current codebase constraints that materially affect implementation:
 
-1. UI has no command palette implementation yet (`apps/ui/src/App.tsx`).
-2. UI command host contracts exist (`apps/ui/src/plugin-commands.ts`) but are not wired into the app shell.
-3. Search passes raw query directly to SQLite FTS (`packages/index-sqlite/src/index.ts`), and queries like `1-15-2026` currently throw SQL/FTS errors.
-4. `applyPluginTemplate` creates a new note every call (not idempotent), so it cannot be used directly for "open today's note" behavior.
+1. UI command palette is implemented in `apps/ui/src/App.tsx` and already shares one note-open path across `Today`, `Add Note`, wiki links, and palette note search results.
+2. UI command host contracts exist (`apps/ui/src/plugin-commands.ts`), but the currently shipped palette items are still app-shell owned rather than plugin-driven.
+3. Search normalizes supported date queries before SQLite FTS execution so inputs like `1-15-2026` stay safe and resolve to daily-note titles.
+4. `POST /daily-notes/today` is the single get-or-create path used by startup and the `Today` command.
 
 ## 3) Functional requirements
 
@@ -209,12 +209,13 @@ By product decision, this always overrides draft-first startup behavior.
 
 ## 7.3 Command palette and Today command
 
-Implement a minimal command palette in app shell:
+Implement/maintain the shared command palette in the app shell:
 
 1. Keyboard shortcut: `Cmd/Ctrl + K`.
-2. Single command item: `Today`.
-3. On run: call `POST /daily-notes/today` with local timezone and open returned note.
-4. If call fails, surface actionable error state in UI.
+2. Suggested actions currently include `Today` and `Add Note`; daily-notes specifically requires that `Today` stays available.
+3. Query text also searches notes through `GET /search?q=...` and opens the selected result through the standard note-open flow.
+4. Running `Today` calls `POST /daily-notes/today` with local timezone and opens the returned note.
+5. If daily-note open, note search, or note open fails, surface actionable error state in UI.
 
 ## 8) Plugin bootstrap policy
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -45,7 +45,7 @@ Key design posture:
 Responsibilities:
 - editor UX (Lexical)
 - wiki-link UX for linking/opening notes
-- note list/sidebar, settings page, and command palette actions (`Today`, `Add Note`)
+- note list/sidebar, settings page, and command palette actions (`Today`, `Add Note`) plus note search/open results powered by the shared search API
 - implemented: editor title field expands across the top bar so long note titles stay visible on one line instead of being capped at a fixed width
 - daily-note startup/open flow via API
 - authentication is local-only (no multi-user in v1)

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -81,7 +81,7 @@ curl "http://127.0.0.1:8787/search?q=2026-01-15"
 
 Expected:
 - UI startup opens/creates today's daily note automatically.
-- command palette (`Cmd/Ctrl+K`) exposes `Today` command.
+- command palette (`Cmd/Ctrl+K`) exposes `Today`, `Add Note`, and query-driven note search/open results backed by `GET /search`.
 - repeated daily-note requests are idempotent per local date key.
 
 ## Plugin lifecycle workflow (CLI)
@@ -195,7 +195,7 @@ bun run --cwd apps/cli src/index.ts proposals reject <proposal-id> --json
 
 UI behavior (current implementation):
 - review and approval are currently performed through CLI/API proposal commands
-- the UI currently focuses on note editing, daily-note startup flow, and command palette actions (`Today`, `Add Note`)
+- the UI currently focuses on note editing, daily-note startup flow, and command palette actions/search (`Today`, `Add Note`, and note open results)
 
 ## Core note/search/events lifecycle (CLI)
 


### PR DESCRIPTION
Summary
- wire the command palette to query `/search` (debounced, limited) and show resulting notes alongside existing commands with navigation/mouse handling
- coalesce suggested commands and note matches into indexed sections with updated UI/ARIA, snippet formatting, and styles so note rows truncate appropriately
- document the new palette behavior in the daily notes spec, design overview, and runbook while keeping documentation aligned with shipped behavior

Testing
- Not run (not requested)