### PR TITLE
Update slate-blue wiki link tokens

### DIFF
--- a/apps/ui/src/styles.css
+++ b/apps/ui/src/styles.css
@@ -10,6 +10,9 @@
   --muted-strong: #b2b4be;
   --accent: #dce0eb;
   --accent-ink: #0f1116;
+  --link: #8fa9ff;
+  --link-hover: #bccbff;
+  --link-underline: #5f7fd6;
   --status-idle: #747985;
   --status-saving: #f4a948;
   --status-success: #44d078;
@@ -29,6 +32,9 @@
   --muted-strong: #4b5360;
   --accent: #1c2330;
   --accent-ink: #f2f5fc;
+  --link: #2e5aac;
+  --link-hover: #21458a;
+  --link-underline: #7a9ad8;
   --status-idle: #5f6674;
   --status-saving: #ca8a2d;
   --status-success: #2f9f59;
@@ -866,14 +872,14 @@ body {
 }
 
 .lexical-editor a[href^="#/note/"] {
-  color: color-mix(in srgb, var(--text) 82%, var(--status-success));
-  text-decoration-color: color-mix(in srgb, var(--text) 36%, transparent);
+  color: var(--link);
+  text-decoration-color: var(--link-underline);
   text-decoration-thickness: 1px;
   text-underline-offset: 0.14em;
 }
 
 .lexical-editor a[href^="#/note/"]:hover {
-  color: var(--text);
+  color: var(--link-hover);
 }
 
 .lexical-text-strikethrough {

--- a/apps/ui/src/styles.test.ts
+++ b/apps/ui/src/styles.test.ts
@@ -23,4 +23,23 @@ describe("command palette styles", () => {
       /\.topbar-title-input\s*{[^}]*min-width:\s*min\(40rem,\s*100%\);/s,
     );
   });
+
+  test("uses explicit slate-blue wiki link tokens instead of status color mixing", () => {
+    expect(stylesCss).toMatch(/:root\s*{[^}]*--link:\s*#8fa9ff;/s);
+    expect(stylesCss).toMatch(/:root\s*{[^}]*--link-hover:\s*#bccbff;/s);
+    expect(stylesCss).toMatch(/:root\s*{[^}]*--link-underline:\s*#5f7fd6;/s);
+    expect(stylesCss).toMatch(/:root\[data-theme="light"\]\s*{[^}]*--link:\s*#2e5aac;/s);
+    expect(stylesCss).toMatch(
+      /\.lexical-editor a\[href\^="#\/note\/"\]\s*{[^}]*color:\s*var\(--link\);/s,
+    );
+    expect(stylesCss).toMatch(
+      /\.lexical-editor a\[href\^="#\/note\/"\]\s*{[^}]*text-decoration-color:\s*var\(--link-underline\);/s,
+    );
+    expect(stylesCss).toMatch(
+      /\.lexical-editor a\[href\^="#\/note\/"\]:hover\s*{[^}]*color:\s*var\(--link-hover\);/s,
+    );
+    expect(stylesCss).not.toMatch(
+      /\.lexical-editor a\[href\^="#\/note\/"\]\s*{[^}]*status-success/s,
+    );
+  });
 });

--- a/docs/design.md
+++ b/docs/design.md
@@ -47,6 +47,7 @@ Responsibilities:
 - wiki-link UX for linking/opening notes
 - note list/sidebar, settings page, and command palette actions (`Today`, `Add Note`) plus note search/open results powered by the shared search API
 - implemented: editor title field expands across the top bar so long note titles stay visible on one line instead of being capped at a fixed width
+- implemented: wiki/note hyperlinks use dedicated theme tokens, with a slate-blue treatment in dark mode for clearer navigation affordance without borrowing success-state color semantics
 - daily-note startup/open flow via API
 - authentication is local-only (no multi-user in v1)
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -26,6 +26,7 @@ Default API: `http://127.0.0.1:8787`
 
 UI smoke check:
 - Open the UI, create a note with a long single-line title, and confirm the editor title field expands horizontally across the top bar so the full title remains visible without wrapping.
+- Switch the UI to dark theme, insert or open a wiki/note link in the editor, and confirm the link renders with the slate-blue link treatment rather than the success green used for status messaging.
 
 ## Binary upgrade workflow (CLI)
 


### PR DESCRIPTION
Summary:
- introduce dedicated light/dark slate blue link color tokens and apply them to the wiki link styles instead of status-success mixes
- add style assertions so the new tokens and hover treatment stay guarded in tests
- document the slate-blue link treatment in both the design overview and the operator smoke check guide
Testing:
- Not run (not requested)