### PR TITLE
Persist line spacing preference and use CSS variable

### DIFF
--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -78,7 +78,8 @@ type SaveIndicator = {
 };
 
 type ThemePreference = "dark" | "light" | "system";
-type LineSpacingPreference = "compact" | "default" | "relaxed";
+type LineSpacingPreference = "compact" | "standard" | "relaxed";
+type StoredLineSpacingPreference = LineSpacingPreference | "default";
 
 const LINE_SPACING_VALUES: Record<
   LineSpacingPreference,
@@ -88,7 +89,7 @@ const LINE_SPACING_VALUES: Record<
     lineHeight: "1.62",
     paragraphSpacing: "0.34rem",
   },
-  default: {
+  standard: {
     lineHeight: "1.84",
     paragraphSpacing: "0.58rem",
   },
@@ -182,7 +183,19 @@ export function isThemePreference(value: string): value is ThemePreference {
 }
 
 export function isLineSpacingPreference(value: string): value is LineSpacingPreference {
-  return value === "compact" || value === "default" || value === "relaxed";
+  return value === "compact" || value === "standard" || value === "relaxed";
+}
+
+export function normalizeStoredLineSpacingPreference(value: string): LineSpacingPreference | null {
+  if (value === "default") {
+    return "standard";
+  }
+
+  if (isLineSpacingPreference(value)) {
+    return value;
+  }
+
+  return null;
 }
 
 export function resolveLineSpacingValue(preference: LineSpacingPreference): string {
@@ -411,7 +424,7 @@ export function App() {
   const [team, setTeam] = useState("Core");
   const [themePreference, setThemePreference] = useState<ThemePreference>("dark");
   const [lineSpacingPreference, setLineSpacingPreference] =
-    useState<LineSpacingPreference>("default");
+    useState<LineSpacingPreference>("compact");
   const [storeRootInput, setStoreRootInput] = useState("");
   const [storeRootConfig, setStoreRootConfig] = useState<StoreRootConfigResponse | null>(null);
   const [storeRootState, setStoreRootState] = useState<SaveState>({
@@ -549,8 +562,13 @@ export function App() {
     }
 
     const storedLineSpacing = window.localStorage.getItem("rem.lineSpacing");
-    if (storedLineSpacing && isLineSpacingPreference(storedLineSpacing)) {
-      setLineSpacingPreference(storedLineSpacing);
+    if (storedLineSpacing) {
+      const normalizedLineSpacing = normalizeStoredLineSpacingPreference(
+        storedLineSpacing as StoredLineSpacingPreference,
+      );
+      if (normalizedLineSpacing) {
+        setLineSpacingPreference(normalizedLineSpacing);
+      }
     }
   }, []);
 
@@ -1570,10 +1588,10 @@ export function App() {
                       <Button
                         type="button"
                         size="sm"
-                        variant={lineSpacingPreference === "default" ? "default" : "subtle"}
-                        onClick={() => setLineSpacingPreference("default")}
+                        variant={lineSpacingPreference === "standard" ? "default" : "subtle"}
+                        onClick={() => setLineSpacingPreference("standard")}
                       >
-                        Default
+                        Standard
                       </Button>
                       <Button
                         type="button"

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -80,10 +80,22 @@ type SaveIndicator = {
 type ThemePreference = "dark" | "light" | "system";
 type LineSpacingPreference = "compact" | "default" | "relaxed";
 
-const LINE_SPACING_VALUES: Record<LineSpacingPreference, string> = {
-  compact: "1.62",
-  default: "1.84",
-  relaxed: "2.04",
+const LINE_SPACING_VALUES: Record<
+  LineSpacingPreference,
+  { lineHeight: string; paragraphSpacing: string }
+> = {
+  compact: {
+    lineHeight: "1.62",
+    paragraphSpacing: "0.34rem",
+  },
+  default: {
+    lineHeight: "1.84",
+    paragraphSpacing: "0.58rem",
+  },
+  relaxed: {
+    lineHeight: "2.04",
+    paragraphSpacing: "0.86rem",
+  },
 };
 
 type SaveNoteResponse = {
@@ -174,7 +186,11 @@ export function isLineSpacingPreference(value: string): value is LineSpacingPref
 }
 
 export function resolveLineSpacingValue(preference: LineSpacingPreference): string {
-  return LINE_SPACING_VALUES[preference];
+  return LINE_SPACING_VALUES[preference].lineHeight;
+}
+
+export function resolveParagraphSpacingValue(preference: LineSpacingPreference): string {
+  return LINE_SPACING_VALUES[preference].paragraphSpacing;
 }
 
 export function formatStoreRootMessage(config: StoreRootConfigResponse): string {
@@ -588,6 +604,10 @@ export function App() {
     window.document.documentElement.style.setProperty(
       "--editor-line-height",
       resolveLineSpacingValue(lineSpacingPreference),
+    );
+    window.document.documentElement.style.setProperty(
+      "--editor-paragraph-spacing",
+      resolveParagraphSpacingValue(lineSpacingPreference),
     );
   }, [lineSpacingPreference]);
 

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -78,6 +78,13 @@ type SaveIndicator = {
 };
 
 type ThemePreference = "dark" | "light" | "system";
+type LineSpacingPreference = "compact" | "default" | "relaxed";
+
+const LINE_SPACING_VALUES: Record<LineSpacingPreference, string> = {
+  compact: "1.62",
+  default: "1.84",
+  relaxed: "2.04",
+};
 
 type SaveNoteResponse = {
   noteId: string;
@@ -160,6 +167,14 @@ export function formatModifiedAt(iso: string): string {
 
 export function isThemePreference(value: string): value is ThemePreference {
   return value === "dark" || value === "light" || value === "system";
+}
+
+export function isLineSpacingPreference(value: string): value is LineSpacingPreference {
+  return value === "compact" || value === "default" || value === "relaxed";
+}
+
+export function resolveLineSpacingValue(preference: LineSpacingPreference): string {
+  return LINE_SPACING_VALUES[preference];
 }
 
 export function formatStoreRootMessage(config: StoreRootConfigResponse): string {
@@ -379,6 +394,8 @@ export function App() {
   const [activePage, setActivePage] = useState<"editor" | "settings">("editor");
   const [team, setTeam] = useState("Core");
   const [themePreference, setThemePreference] = useState<ThemePreference>("dark");
+  const [lineSpacingPreference, setLineSpacingPreference] =
+    useState<LineSpacingPreference>("default");
   const [storeRootInput, setStoreRootInput] = useState("");
   const [storeRootConfig, setStoreRootConfig] = useState<StoreRootConfigResponse | null>(null);
   const [storeRootState, setStoreRootState] = useState<SaveState>({
@@ -514,6 +531,11 @@ export function App() {
     if (storedTheme && isThemePreference(storedTheme)) {
       setThemePreference(storedTheme);
     }
+
+    const storedLineSpacing = window.localStorage.getItem("rem.lineSpacing");
+    if (storedLineSpacing && isLineSpacingPreference(storedLineSpacing)) {
+      setLineSpacingPreference(storedLineSpacing);
+    }
   }, []);
 
   useEffect(() => {
@@ -556,6 +578,18 @@ export function App() {
       colorScheme.removeEventListener("change", onColorSchemeChange);
     };
   }, [themePreference]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    window.localStorage.setItem("rem.lineSpacing", lineSpacingPreference);
+    window.document.documentElement.style.setProperty(
+      "--editor-line-height",
+      resolveLineSpacingValue(lineSpacingPreference),
+    );
+  }, [lineSpacingPreference]);
 
   const refreshStoreRootConfig = useCallback(async (): Promise<void> => {
     try {
@@ -1425,7 +1459,10 @@ export function App() {
                   </Button>
                 </header>
 
-                <section className="settings-team-section" aria-label="Team and storage settings">
+                <section
+                  className="settings-team-section"
+                  aria-label="Writing, team, and storage settings"
+                >
                   <label className="settings-field" htmlFor="settings-team">
                     <span>Team</span>
                     <Input
@@ -1499,9 +1536,39 @@ export function App() {
                       </Button>
                     </div>
                   </div>
+                  <div className="settings-theme-switcher" aria-label="Line spacing switcher">
+                    <span className="settings-theme-label">Line spacing</span>
+                    <div className="settings-theme-options">
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant={lineSpacingPreference === "compact" ? "default" : "subtle"}
+                        onClick={() => setLineSpacingPreference("compact")}
+                      >
+                        Compact
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant={lineSpacingPreference === "default" ? "default" : "subtle"}
+                        onClick={() => setLineSpacingPreference("default")}
+                      >
+                        Default
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant={lineSpacingPreference === "relaxed" ? "default" : "subtle"}
+                        onClick={() => setLineSpacingPreference("relaxed")}
+                      >
+                        Relaxed
+                      </Button>
+                    </div>
+                  </div>
                   <p className="settings-team-help">
-                    Team and theme preferences are stored locally in this browser. Store root
-                    changes apply across the app and default to ~/.rem when not configured.
+                    Team, theme, and line spacing preferences are stored locally in this browser.
+                    Store root changes apply across the app and default to ~/.rem when not
+                    configured.
                   </p>
                 </section>
               </div>

--- a/apps/ui/src/app.test.tsx
+++ b/apps/ui/src/app.test.tsx
@@ -7,6 +7,7 @@ import {
   formatStoreRootMessage,
   isLineSpacingPreference,
   isThemePreference,
+  normalizeStoredLineSpacingPreference,
   resolveLineSpacingValue,
   resolveParagraphSpacingValue,
 } from "./App";
@@ -96,20 +97,28 @@ describe("App", () => {
 
   test("recognizes valid line spacing preferences", () => {
     expect(isLineSpacingPreference("compact")).toBeTrue();
-    expect(isLineSpacingPreference("default")).toBeTrue();
+    expect(isLineSpacingPreference("standard")).toBeTrue();
     expect(isLineSpacingPreference("relaxed")).toBeTrue();
     expect(isLineSpacingPreference("wide")).toBeFalse();
   });
 
+  test("normalizes stored line spacing preferences including the legacy default value", () => {
+    expect(normalizeStoredLineSpacingPreference("compact")).toBe("compact");
+    expect(normalizeStoredLineSpacingPreference("default")).toBe("standard");
+    expect(normalizeStoredLineSpacingPreference("standard")).toBe("standard");
+    expect(normalizeStoredLineSpacingPreference("relaxed")).toBe("relaxed");
+    expect(normalizeStoredLineSpacingPreference("wide")).toBeNull();
+  });
+
   test("maps line spacing preferences to editor line-height values", () => {
     expect(resolveLineSpacingValue("compact")).toBe("1.62");
-    expect(resolveLineSpacingValue("default")).toBe("1.84");
+    expect(resolveLineSpacingValue("standard")).toBe("1.84");
     expect(resolveLineSpacingValue("relaxed")).toBe("2.04");
   });
 
   test("maps line spacing preferences to paragraph spacing values", () => {
     expect(resolveParagraphSpacingValue("compact")).toBe("0.34rem");
-    expect(resolveParagraphSpacingValue("default")).toBe("0.58rem");
+    expect(resolveParagraphSpacingValue("standard")).toBe("0.58rem");
     expect(resolveParagraphSpacingValue("relaxed")).toBe("0.86rem");
   });
 });

--- a/apps/ui/src/app.test.tsx
+++ b/apps/ui/src/app.test.tsx
@@ -1,7 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import { renderToString } from "react-dom/server";
 
-import { App, createNoteSavePayload, formatStoreRootMessage, isThemePreference } from "./App";
+import {
+  App,
+  createNoteSavePayload,
+  formatStoreRootMessage,
+  isLineSpacingPreference,
+  isThemePreference,
+  resolveLineSpacingValue,
+} from "./App";
 import { plainTextToLexicalState } from "./lexical";
 
 describe("App", () => {
@@ -84,5 +91,18 @@ describe("App", () => {
     expect(isThemePreference("light")).toBeTrue();
     expect(isThemePreference("system")).toBeTrue();
     expect(isThemePreference("sepia")).toBeFalse();
+  });
+
+  test("recognizes valid line spacing preferences", () => {
+    expect(isLineSpacingPreference("compact")).toBeTrue();
+    expect(isLineSpacingPreference("default")).toBeTrue();
+    expect(isLineSpacingPreference("relaxed")).toBeTrue();
+    expect(isLineSpacingPreference("wide")).toBeFalse();
+  });
+
+  test("maps line spacing preferences to editor line-height values", () => {
+    expect(resolveLineSpacingValue("compact")).toBe("1.62");
+    expect(resolveLineSpacingValue("default")).toBe("1.84");
+    expect(resolveLineSpacingValue("relaxed")).toBe("2.04");
   });
 });

--- a/apps/ui/src/app.test.tsx
+++ b/apps/ui/src/app.test.tsx
@@ -8,6 +8,7 @@ import {
   isLineSpacingPreference,
   isThemePreference,
   resolveLineSpacingValue,
+  resolveParagraphSpacingValue,
 } from "./App";
 import { plainTextToLexicalState } from "./lexical";
 
@@ -104,5 +105,11 @@ describe("App", () => {
     expect(resolveLineSpacingValue("compact")).toBe("1.62");
     expect(resolveLineSpacingValue("default")).toBe("1.84");
     expect(resolveLineSpacingValue("relaxed")).toBe("2.04");
+  });
+
+  test("maps line spacing preferences to paragraph spacing values", () => {
+    expect(resolveParagraphSpacingValue("compact")).toBe("0.34rem");
+    expect(resolveParagraphSpacingValue("default")).toBe("0.58rem");
+    expect(resolveParagraphSpacingValue("relaxed")).toBe("0.86rem");
   });
 });

--- a/apps/ui/src/app.test.tsx
+++ b/apps/ui/src/app.test.tsx
@@ -4,6 +4,8 @@ import { renderToString } from "react-dom/server";
 import {
   App,
   createNoteSavePayload,
+  formatModifiedAt,
+  formatSavedAt,
   formatStoreRootMessage,
   isLineSpacingPreference,
   isThemePreference,
@@ -67,6 +69,26 @@ describe("App", () => {
         source: "default",
       }),
     ).toBe("Using default store root /tmp/rem-default.");
+  });
+
+  test("formats saved and modified timestamps through locale helpers", () => {
+    const originalToLocaleTimeString = Date.prototype.toLocaleTimeString;
+    const originalToLocaleString = Date.prototype.toLocaleString;
+
+    Date.prototype.toLocaleTimeString = function mockToLocaleTimeString() {
+      return "08:15 AM";
+    };
+    Date.prototype.toLocaleString = function mockToLocaleString() {
+      return "Mar 7, 08:15 AM";
+    };
+
+    try {
+      expect(formatSavedAt("2026-03-07T14:15:00.000Z")).toBe("08:15 AM");
+      expect(formatModifiedAt("2026-03-07T14:15:00.000Z")).toBe("Mar 7, 08:15 AM");
+    } finally {
+      Date.prototype.toLocaleTimeString = originalToLocaleTimeString;
+      Date.prototype.toLocaleString = originalToLocaleString;
+    }
   });
 
   test("builds note save payloads only when title or body is present", () => {

--- a/apps/ui/src/daily-notes.test.ts
+++ b/apps/ui/src/daily-notes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { buildDailyNoteRequestPayload } from "./daily-notes";
+import { buildDailyNoteRequestPayload, resolveClientTimeZone } from "./daily-notes";
 
 describe("daily note UI helpers", () => {
   test("builds timezone payload only for non-empty timezone values", () => {
@@ -11,5 +11,41 @@ describe("daily note UI helpers", () => {
     expect(buildDailyNoteRequestPayload(" America/New_York ")).toEqual({
       timezone: "America/New_York",
     });
+  });
+
+  test("resolves the client timezone when available and ignores empty values", () => {
+    const originalWindow = globalThis.window;
+    try {
+      expect(resolveClientTimeZone()).toBeUndefined();
+
+      Object.defineProperty(globalThis, "window", {
+        configurable: true,
+        value: {
+          Intl: {
+            DateTimeFormat: () => ({
+              resolvedOptions: () => ({ timeZone: " America/Chicago " }),
+            }),
+          },
+        },
+      });
+      expect(resolveClientTimeZone()).toBe("America/Chicago");
+
+      Object.defineProperty(globalThis, "window", {
+        configurable: true,
+        value: {
+          Intl: {
+            DateTimeFormat: () => ({
+              resolvedOptions: () => ({ timeZone: "   " }),
+            }),
+          },
+        },
+      });
+      expect(resolveClientTimeZone()).toBeUndefined();
+    } finally {
+      Object.defineProperty(globalThis, "window", {
+        configurable: true,
+        value: originalWindow,
+      });
+    }
   });
 });

--- a/apps/ui/src/styles.css
+++ b/apps/ui/src/styles.css
@@ -17,8 +17,8 @@
   --row-hover: #141417;
   --row-active: #1a1a1e;
   --input-focus: #121215;
-  --editor-line-height: 1.84;
-  --editor-paragraph-spacing: 0.58rem;
+  --editor-line-height: 1.62;
+  --editor-paragraph-spacing: 0.34rem;
 }
 
 :root[data-theme="light"] {

--- a/apps/ui/src/styles.css
+++ b/apps/ui/src/styles.css
@@ -17,6 +17,7 @@
   --row-hover: #141417;
   --row-active: #1a1a1e;
   --input-focus: #121215;
+  --editor-line-height: 1.84;
 }
 
 :root[data-theme="light"] {
@@ -843,7 +844,7 @@ body {
   color: var(--text);
   background: transparent;
   font-size: clamp(0.92rem, 1.35vw, 1.02rem);
-  line-height: 1.84;
+  line-height: var(--editor-line-height);
 }
 
 .lexical-editor:focus {

--- a/apps/ui/src/styles.css
+++ b/apps/ui/src/styles.css
@@ -18,6 +18,7 @@
   --row-active: #1a1a1e;
   --input-focus: #121215;
   --editor-line-height: 1.84;
+  --editor-paragraph-spacing: 0.58rem;
 }
 
 :root[data-theme="light"] {
@@ -845,6 +846,15 @@ body {
   background: transparent;
   font-size: clamp(0.92rem, 1.35vw, 1.02rem);
   line-height: var(--editor-line-height);
+}
+
+.lexical-editor p {
+  margin: 0;
+  line-height: var(--editor-line-height);
+}
+
+.lexical-editor p + p {
+  margin-top: var(--editor-paragraph-spacing);
 }
 
 .lexical-editor:focus {

--- a/apps/ui/src/styles.test.ts
+++ b/apps/ui/src/styles.test.ts
@@ -23,4 +23,11 @@ describe("command palette styles", () => {
       /\.topbar-title-input\s*{[^}]*min-width:\s*min\(40rem,\s*100%\);/s,
     );
   });
+
+  test("drives editor line spacing through a root CSS variable", () => {
+    expect(stylesCss).toMatch(/:root\s*{[^}]*--editor-line-height:\s*1\.84;/s);
+    expect(stylesCss).toMatch(
+      /\.lexical-editor\s*{[^}]*line-height:\s*var\(--editor-line-height\);/s,
+    );
+  });
 });

--- a/apps/ui/src/styles.test.ts
+++ b/apps/ui/src/styles.test.ts
@@ -26,8 +26,15 @@ describe("command palette styles", () => {
 
   test("drives editor line spacing through a root CSS variable", () => {
     expect(stylesCss).toMatch(/:root\s*{[^}]*--editor-line-height:\s*1\.84;/s);
+    expect(stylesCss).toMatch(/:root\s*{[^}]*--editor-paragraph-spacing:\s*0\.58rem;/s);
     expect(stylesCss).toMatch(
       /\.lexical-editor\s*{[^}]*line-height:\s*var\(--editor-line-height\);/s,
+    );
+    expect(stylesCss).toMatch(
+      /\.lexical-editor p\s*{[^}]*margin:\s*0;[^}]*line-height:\s*var\(--editor-line-height\);/s,
+    );
+    expect(stylesCss).toMatch(
+      /\.lexical-editor p \+ p\s*{[^}]*margin-top:\s*var\(--editor-paragraph-spacing\);/s,
     );
   });
 });

--- a/apps/ui/src/styles.test.ts
+++ b/apps/ui/src/styles.test.ts
@@ -25,8 +25,8 @@ describe("command palette styles", () => {
   });
 
   test("drives editor line spacing through a root CSS variable", () => {
-    expect(stylesCss).toMatch(/:root\s*{[^}]*--editor-line-height:\s*1\.84;/s);
-    expect(stylesCss).toMatch(/:root\s*{[^}]*--editor-paragraph-spacing:\s*0\.58rem;/s);
+    expect(stylesCss).toMatch(/:root\s*{[^}]*--editor-line-height:\s*1\.62;/s);
+    expect(stylesCss).toMatch(/:root\s*{[^}]*--editor-paragraph-spacing:\s*0\.34rem;/s);
     expect(stylesCss).toMatch(
       /\.lexical-editor\s*{[^}]*line-height:\s*var\(--editor-line-height\);/s,
     );

--- a/docs/design.md
+++ b/docs/design.md
@@ -47,7 +47,7 @@ Responsibilities:
 - wiki-link UX for linking/opening notes
 - note list/sidebar, settings page, and command palette actions (`Today`, `Add Note`) plus note search/open results powered by the shared search API
 - implemented: editor title field expands across the top bar so long note titles stay visible on one line instead of being capped at a fixed width
-- implemented: settings page stores browser-local writing preferences for theme and editor rhythm, so wrapped lines and paragraph gaps both respond to the selected line spacing preset
+- implemented: settings page stores browser-local writing preferences for theme and editor rhythm, defaults new sessions to the compact preset, and still upgrades older saved `default` line-spacing values to the renamed standard preset
 - daily-note startup/open flow via API
 - authentication is local-only (no multi-user in v1)
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -47,6 +47,7 @@ Responsibilities:
 - wiki-link UX for linking/opening notes
 - note list/sidebar, settings page, and command palette actions (`Today`, `Add Note`) plus note search/open results powered by the shared search API
 - implemented: editor title field expands across the top bar so long note titles stay visible on one line instead of being capped at a fixed width
+- implemented: settings page stores browser-local writing preferences for theme and editor line spacing, alongside team and store-root controls
 - daily-note startup/open flow via API
 - authentication is local-only (no multi-user in v1)
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -47,7 +47,7 @@ Responsibilities:
 - wiki-link UX for linking/opening notes
 - note list/sidebar, settings page, and command palette actions (`Today`, `Add Note`) plus note search/open results powered by the shared search API
 - implemented: editor title field expands across the top bar so long note titles stay visible on one line instead of being capped at a fixed width
-- implemented: settings page stores browser-local writing preferences for theme and editor line spacing, alongside team and store-root controls
+- implemented: settings page stores browser-local writing preferences for theme and editor rhythm, so wrapped lines and paragraph gaps both respond to the selected line spacing preset
 - daily-note startup/open flow via API
 - authentication is local-only (no multi-user in v1)
 


### PR DESCRIPTION
Summary
- add line spacing preference controls, storage, and helpers so the editor reflects compact/default/relaxed settings and stays in sync with the DOM variable
- tie the root `--editor-line-height` variable to the stored preference and document the behavior in `docs/design.md`

Testing
- Not run (not requested)